### PR TITLE
fbxclassid noctor

### DIFF
--- a/src/fbxclassid.i
+++ b/src/fbxclassid.i
@@ -5,6 +5,10 @@
 // As the ignore everything will include the constructor, destructor, methods etc
 // in the class, these have to be explicitly unignored too:
 %rename("%s") FbxClassId::GetName;
+
+/* Ignore the constructors for class Id. */
+%ignore FbxClassId::FbxClassId;
+
 #else
 /* Ignore the constructors for class Id. */
 %ignore FbxClassId::FbxClassId;


### PR DESCRIPTION
We need to explicitly ignore FbxClassId constructor when we have the IGNORE_ALL_INCLUDE_SOME otherwise the constructors show up again. 