### PR TITLE
FbxManager and FbxObject now destroy when they're disposed.

### DIFF
--- a/src/FbxSharpObjectLifetime.i
+++ b/src/FbxSharpObjectLifetime.i
@@ -137,6 +137,9 @@ extern "C" SWIGEXPORT int SWIGSTDCALL CSharp_$module_InitFbxAllocators() {
   }
   protected void Dispose(bool disposing) {
     if (swigCPtr.Handle != global::System.IntPtr.Zero) {
+      if (disposing) {
+        Destroy();
+      }
       lock(this) {
         $modulePINVOKE.ReleaseWeakPointerHandle(swigCPtr);
         swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);

--- a/src/fbxemitter.i
+++ b/src/fbxemitter.i
@@ -1,8 +1,20 @@
 #ifdef IGNORE_ALL_INCLUDE_SOME
 // Unignore class
 %rename("%s") FbxEmitter;
+%rename("%s") FbxEmitter::Destroy;
 %nodefaultctor FbxEmitter;
+
 #endif
+
+/*
+ * While FbxEmitter doesn't have a Destroy function, everything else whose
+ * memory we manage does. So invent one. This way we can call Destroy on
+ * anything we manage. Because it's listed as virtual here, the C# side
+ * uses dynamic dispatch.
+ */
+%extend FbxEmitter {
+  virtual void Destroy(bool recursive = false) { }
+}
 
 %include "fbxsdk/core/fbxemitter.h"
 

--- a/tests/UnityTests/Assets/Editor/UnitTests/FbxManagerTest.cs
+++ b/tests/UnityTests/Assets/Editor/UnitTests/FbxManagerTest.cs
@@ -81,5 +81,16 @@ namespace UnitTests
                 Assert.AreSame (m_fbxManager, fbxManager2);
             }
         }
+
+        [Test]
+        public void TestUsing ()
+        {
+            // Test that the using statement works, and destroys the manager.
+            FbxObject obj;
+            using (var mgr = FbxManager.Create ()) {
+                obj = FbxObject.Create(mgr, "asdf");
+            }
+            Assert.That(() => { obj.GetName (); }, Throws.Exception.TypeOf<System.ArgumentNullException>());
+        }
     }
 }


### PR DESCRIPTION
This is only on an explicit Dispose() call or in a using statment. If they're
finalized just because you dropped all references, they don't destroy.

For FbxObject that's good semantics.

For FbxManager it's debatable. We might want to destroy on finalize. To be discussed.