### PR TITLE
Uni-12954 export example (empty scene)

### DIFF
--- a/examples/export/Assets/Editor/FbxExporter01.cs
+++ b/examples/export/Assets/Editor/FbxExporter01.cs
@@ -122,14 +122,22 @@ namespace FbxSdk.Examples
             private static void OnExport()
             {
                 // Now that we know we have stuff to export, get the user-desired path.
-                var directory = string.IsNullOrEmpty (LastFilePath) ? Application.dataPath : System.IO.Path.GetDirectoryName (LastFilePath);
-                var filename = string.IsNullOrEmpty (LastFilePath) ? MakeFileName(basename: Basename, extension: Extension) : System.IO.Path.GetFileName (LastFilePath);
+                var directory = string.IsNullOrEmpty (LastFilePath) 
+                                      ? Application.dataPath 
+                                      : System.IO.Path.GetDirectoryName (LastFilePath);
+                
+                var filename = string.IsNullOrEmpty (LastFilePath) 
+                                     ? MakeFileName(basename: Basename, extension: Extension) 
+                                     : System.IO.Path.GetFileName (LastFilePath);
+                
                 var title = string.Format ("Export FBX ({0})", Basename);
 
                 var filePath = EditorUtility.SaveFilePanel (title, directory, filename, "");
+
                 if (string.IsNullOrEmpty (filePath)) {
                     return;
                 }
+
                 LastFilePath = filePath;
 
                 using (exporter01 exporter = new exporter01()) {


### PR DESCRIPTION
hacked the imaginary spaces exporter into an fbxsdk example exporter.

imports an empty scene which is not very exciting.

