### PR TITLE
Uni 13978 hierarchy export

### DIFF
--- a/src/fbxscene.i
+++ b/src/fbxscene.i
@@ -13,6 +13,7 @@
 %rename("%s") FbxScene::GetNodeCount;
 %rename("%s") FbxScene::GetSceneInfo;
 %rename("%s") FbxScene::SetSceneInfo;
+%rename("%s") FbxScene::GetRootNode;
 #endif
 
 %include "fbxsdk/scene/fbxscene.h"


### PR DESCRIPTION
- export selected GameObjects and their children
- creates and exports the FbxNode graph for the selected GameObjects. 
- generated FBX can be reimported into Unity using built in importer
- the node graph contains only the names of the GameObjects and their hierarchy, no transform or other info is included