### PR TITLE
UNI-15322 resolve ubuntu compile errors

### DIFF
--- a/src/WeakPointerHandle.cxx
+++ b/src/WeakPointerHandle.cxx
@@ -2,7 +2,6 @@
 
 /* The handle class for weak pointers. */
 #include <unordered_map>
-#include <inttypes.h>
 
 struct WeakPointerHandle;
 typedef std::unordered_map<void*, WeakPointerHandle*> HandleMap;
@@ -50,7 +49,7 @@ struct WeakPointerHandle {
     void ReleaseReference() {
 #ifdef MEMORY_DEBUG
         if (m_ptr != 0) {
-          fprintf(stderr, "Releasing %" PRId64 " (%d refs)\n", uint64_t(m_ptr), m_numRefs);
+          fprintf(stderr, "Releasing %p (%d refs)\n", m_ptr, m_numRefs);
           assert(AllocatedBlocks.count(m_ptr) != 0);
         }
 #endif
@@ -79,7 +78,7 @@ struct WeakPointerHandle {
             if (!p) { return; }
             #ifdef MEMORY_DEBUG
             if (AllocatedBlocks.find(p) == AllocatedBlocks.end()) {
-                fprintf(stderr, "Duplicate free at %" PRId64 "\n", uint64_t(p));
+                fprintf(stderr, "Duplicate free at %p\n", p);
                 assert(AllocatedBlocks.count(p) != 0);
             }
             AllocatedBlocks.erase(p);
@@ -93,7 +92,7 @@ struct WeakPointerHandle {
         static inline void MarkAllocated(void *p) {
             #ifdef MEMORY_DEBUG
             if (!AllocatedBlocks.insert(p).second) {
-                fprintf(stderr, "Duplicate allocation at %" PRId64 "\n", uint64_t(p));
+                fprintf(stderr, "Duplicate allocation at %p\n", p);
                 assert(AllocatedBlocks.count(p) == 0);
             }
             #endif


### PR DESCRIPTION
This fixes the following warning:
warning: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]