### PR TITLE
UNI-16195 Allow setting version on export.

### DIFF
--- a/examples/export/Assets/Editor/FbxExporter01.cs
+++ b/examples/export/Assets/Editor/FbxExporter01.cs
@@ -58,35 +58,15 @@ namespace FbxSdk.Examples
                     // Create the exporter 
                     var fbxExporter = FbxExporter.Create (fbxManager, MakeObjectName ("Exporter"));
 
-                    // Find first FBX ASCII file format
-                    int fileFormat = -1;
-
-                    using (var ioPluginRegistry = fbxManager.GetIOPluginRegistry ()) 
-                    {
-                        int fileFormatCount = ioPluginRegistry.GetWriterFormatCount ();
-
-                        for (int formatIndex = 0; formatIndex < fileFormatCount; formatIndex++) 
-                        {
-                            if (ioPluginRegistry.WriterIsFBX (formatIndex)) {
-                                string description = ioPluginRegistry.GetWriterFormatDescription (formatIndex);
-
-                                if (description.IndexOf ("ascii") >= 0)
-                                {
-                                    fileFormat = formatIndex;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
                     // Initialize the exporter.
-                    bool status = fbxExporter.Initialize (LastFilePath, fileFormat, fbxManager.GetIOSettings ());
+                    bool status = fbxExporter.Initialize (LastFilePath);
                     // Check that initialization of the fbxExporter was successful
                     if (!status)
                         return 0;
 
-                    // Configure export version compatibility
-                    fbxExporter.SetFileExportVersion (Globals.FBX_2016_00_COMPATIBLE);
+                    // By default, FBX exports in its most recent version. You might want to specify
+                    // an older version for compatibility with other applications.
+                    fbxExporter.SetFileExportVersion("FBX201400");
 
                     // Create a scene
                     var fbxScene = FbxScene.Create (fbxManager, MakeObjectName ("Scene"));

--- a/examples/export/Assets/Editor/FbxExporter02.cs
+++ b/examples/export/Assets/Editor/FbxExporter02.cs
@@ -87,6 +87,10 @@ namespace FbxSdk.Examples
                     if (!status)
                         return 0;
 
+                    // By default, FBX exports in its most recent version. You might want to specify
+                    // an older version for compatibility with other applications.
+                    fbxExporter.SetFileExportVersion("FBX201400");
+
                     // Create a scene
                     var fbxScene = FbxScene.Create (fbxManager, MakeObjectName ("Scene"));
 

--- a/examples/export/Assets/Editor/FbxExporter03.cs
+++ b/examples/export/Assets/Editor/FbxExporter03.cs
@@ -117,6 +117,10 @@ namespace FbxSdk.Examples
                         return 0;
                     }
 
+                    // By default, FBX exports in its most recent version. You might want to specify
+                    // an older version for compatibility with other applications.
+                    fbxExporter.SetFileExportVersion("FBX201400");
+
                     // Create a scene
                     var fbxScene = FbxScene.Create (fbxManager, MakeObjectName ("Scene"));
 

--- a/examples/export/Assets/Editor/FbxExporter04.cs
+++ b/examples/export/Assets/Editor/FbxExporter04.cs
@@ -155,6 +155,10 @@ namespace FbxSdk.Examples
                     if (!status)
                         return 0;
 
+                    // By default, FBX exports in its most recent version. You might want to specify
+                    // an older version for compatibility with other applications.
+                    fbxExporter.SetFileExportVersion("FBX201400");
+
                     // Create a scene
                     var fbxScene = FbxScene.Create (fbxManager, MakeObjectName ("Scene"));
 

--- a/examples/export/Assets/Editor/FbxExporter05.cs
+++ b/examples/export/Assets/Editor/FbxExporter05.cs
@@ -335,6 +335,10 @@ namespace FbxSdk.Examples
                     if (!status)
                         return 0;
 
+                    // By default, FBX exports in its most recent version. You might want to specify
+                    // an older version for compatibility with other applications.
+                    fbxExporter.SetFileExportVersion("FBX201400");
+
                     // Create a scene
                     var fbxScene = FbxScene.Create (fbxManager, MakeObjectName ("Scene"));
 

--- a/src/fbxexporter.i
+++ b/src/fbxexporter.i
@@ -6,20 +6,47 @@
 // ***********************************************************************
 
 #ifdef IGNORE_ALL_INCLUDE_SOME
-
-// Unignore class
 %rename("%s") FbxExporter;
-
-
 %rename("%s") FbxExporter::Export(FbxDocument *pDocument);
-
-#else
-
-%ignore FbxExporter::SetProgressCallback;
-%apply bool & OUTPUT { bool & pExportResult };
-%nodefaultdtor;                                 // Disable creation of default constructors
-
+%rename("%s") FbxExporter::SetFileExportVersion(FbxString pVersion);
 #endif
+
+/* TODO: implement this! */
+%ignore FbxExporter::SetProgressCallback;
+
+%apply bool & OUTPUT { bool & pExportResult };
+
+/* Described as obsolete but not deprecated. */
+%ignore FbxExporter::SetResamplingRate;
+%ignore FbxExporter::SetDefaultRenderResolution;
+
+/* GetCurrentWritableVersions returns a null-terminated list of strings. That
+ * takes some handling. */
+%ignore FbxExporter::GetCurrentWritableVersions;
+%rename ("%s") FbxExporter::_getCurrentWritableVersionsLength;
+%rename ("%s") FbxExporter::_getCurrentWritableVersionByIndex;
+%extend FbxExporter {
+  %csmethodmodifiers _getCurrentWritableVersionsLength "private";
+  %csmethodmodifiers _getCurrentWritableVersionByIndex "private";
+  int _getCurrentWritableVersionsLength () {
+    auto versions = $self->GetCurrentWritableVersions();
+    int i = 0;
+    for( ; versions[i] != nullptr; ++i) { }
+    return i;
+  }
+  const char *_getCurrentWritableVersionByIndex(int i) {
+    return $self->GetCurrentWritableVersions()[i];
+  }
+  %proxycode %{
+  public string[] GetCurrentWritableVersions() {
+    var versions = new string[_getCurrentWritableVersionsLength()];
+    for(int i = 0, n = versions.Length; i < n; ++i) {
+      versions[i] = _getCurrentWritableVersionByIndex(i);
+    }
+    return versions;
+  }
+  %}
+}
 
 #ifndef SWIG_GENERATING_TYPEDEFS
 // TODO: should we be more specific, test each function in turn for whether it can

--- a/tests/UnityTests/Assets/Editor/UnitTests/FbxExporterTest.cs
+++ b/tests/UnityTests/Assets/Editor/UnitTests/FbxExporterTest.cs
@@ -10,7 +10,6 @@ using System.IO;
 
 namespace UnitTests
 {
-
     public class FbxExporterTest : Base<FbxExporter>
     {
         FbxExporter m_exporter;
@@ -79,6 +78,19 @@ namespace UnitTests
 
             // delete all files that were created
             Directory.Delete(m_testFolder, true);
+        }
+
+        [Test]
+        public void TestBasics()
+        {
+            // Call each function that doesn't write a file, just to see whether it crashes.
+            using (var exporter = CreateObject()) { exporter.Initialize("foo.fbx"); }
+            using (var exporter = CreateObject()) { exporter.Initialize("foo.fbx", -1); }
+            using (var exporter = CreateObject()) { exporter.Initialize("foo.fbx", -1, null); }
+
+            m_exporter.Initialize("foo.fbx");
+            m_exporter.SetFileExportVersion("FBX201400");
+            m_exporter.GetCurrentWritableVersions();
         }
 
         [Test]


### PR DESCRIPTION
Export in 2014-compatible format in the examples.

@inwoods and I had old copies of blender, which crashed on the default 2016-compatible FBX because formats until 2016 used 32-bit ints while 2016 switches to 64-bit.

While I was at it, made FbxExporter have full test coverage.