### PR TITLE
UNI-17444 export textures as embedded

### DIFF
--- a/examples/export/Assets/Editor/FbxExporter06.cs
+++ b/examples/export/Assets/Editor/FbxExporter06.cs
@@ -286,6 +286,9 @@ namespace FbxSdk.Examples
                     // Configure fbx IO settings.
                     fbxManager.SetIOSettings (FbxIOSettings.Create (fbxManager, Globals.IOSROOT));
 
+                    // Export texture as embedded
+                    fbxManager.GetIOSettings ().SetBoolProp (Globals.EXP_FBX_EMBEDDED, true);
+
                     // Create the exporter
                     var fbxExporter = FbxExporter.Create (fbxManager, "Exporter");
 

--- a/src/fbxiobase.i
+++ b/src/fbxiobase.i
@@ -18,6 +18,7 @@
 
 /* Also include global constants that should seemingly be a part of FbxIOBase */
 %rename("%s") IOSROOT;
+%rename("%s") EXP_FBX_EMBEDDED;
 %include "fbxsdk/fileio/fbxiosettingspath.h"
 
 %include "fbxsdk/fileio/fbxiobase.h"

--- a/src/fbxiosettings.i
+++ b/src/fbxiosettings.i
@@ -5,9 +5,8 @@
 // See LICENSE.md file in the project root for full license information.
 // ***********************************************************************
 
-#ifdef IGNORE_ALL_INCLUDE_SOME
 // Unignore class
-%rename("%s") FbxIOSettings;
-#endif
+%rename("%s", %$isclass) FbxIOSettings;
+%rename("%s") FbxIOSettings::SetBoolProp;
 
 %include "fbxsdk/fileio/fbxiosettings.h"

--- a/tests/UnityTests/Assets/Editor/UnitTests/FbxIOSettingsTest.cs
+++ b/tests/UnityTests/Assets/Editor/UnitTests/FbxIOSettingsTest.cs
@@ -41,5 +41,18 @@ namespace UnitTests
                 Assert.AreEqual (ioSettings1, ioSettings2);
             }
         }
+
+        [Test]
+        public void TestSetBoolProp()
+        {
+            // just make sure it doesn't crash
+            using (FbxIOSettings ioSettings = FbxIOSettings.Create (Manager, "")) {
+                ioSettings.SetBoolProp (Globals.EXP_FBX_EMBEDDED, true);
+                ioSettings.SetBoolProp ("", true);
+
+                // TODO: passing null string crashes Unity
+                //ioSettings.SetBoolProp (null, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
cannot embed textures if FBX format is ascii

Needs to be tested on Mac to make sure it works.