### PR TITLE
Define comparison operators for time.

### DIFF
--- a/src/fbxtime.i
+++ b/src/fbxtime.i
@@ -21,11 +21,17 @@
 %rename("%s") FbxTime::EMode;
 %rename("%s") FbxTime::EProtocol;
 
-
-%define_equality_from_operator(FbxTime);
+/* Equality and comparison operators.
+ * We implement both IComparable<FbxTime> and IEquatable<FbxTime> */
+%define_comparison_functions(FbxTime);
 %extend FbxTime { %proxycode %{
   public override int GetHashCode() { return GetRaw().GetHashCode(); }
+  public int CompareTo(FbxTime other) {
+    if (object.ReferenceEquals(other, null)) { return 1; }
+    return GetRaw().CompareTo(other.GetRaw());
+  }
 %} }
+%typemap(csinterfaces) THETYPE "IDisposable, IEquatable<FbxTime>, IComparable<FbxTime>";
 
 /*
  * https://developer.blender.org/T48610

--- a/tests/UnityTests/Assets/Editor/UnitTests/EqualityTester.cs
+++ b/tests/UnityTests/Assets/Editor/UnitTests/EqualityTester.cs
@@ -63,6 +63,9 @@ namespace UnitTests
 #endif
         }
 
+        /* Instances of this class definitely don't cast to T. */
+        class WrongClass { };
+
         /*
          * Test all the equality and hashing functions on type T.
          *
@@ -74,6 +77,11 @@ namespace UnitTests
          * notion of equality for this type is reference equality)
          */
         public static void TestEquality(T a, T b, T acopy) {
+            // Test Equals(object) on a.
+            Assert.IsTrue(a.Equals((object) acopy));
+            Assert.IsFalse(a.Equals((object) b));
+            Assert.IsFalse(a.Equals((object) new WrongClass()));
+
             // Test all the Equals functions on a.
             // a.Equals(a) is true
             // a.Equals(b) is false

--- a/tests/UnityTests/Assets/Editor/UnitTests/FbxTimeTest.cs
+++ b/tests/UnityTests/Assets/Editor/UnitTests/FbxTimeTest.cs
@@ -14,6 +14,31 @@ namespace UnitTests
     public class FbxTimeTest : TestBase<FbxTime>
     {
         [Test]
+        public void TestComparison ()
+        {
+            var a = FbxTime.FromSecondDouble(5);
+            var b = FbxTime.FromSecondDouble(6);
+            var acopy = FbxTime.FromSecondDouble(5);
+
+            // Test equality.
+            EqualityTester<FbxTime>.TestEquality(a, b, acopy);
+
+            // Test inequality.
+            Assert.IsTrue(a.CompareTo(b) < 0);
+            Assert.IsTrue(b.CompareTo(a) > 0);
+            Assert.IsTrue(a.CompareTo(acopy) == 0);
+            Assert.IsTrue(a.CompareTo((object)null) > 0);
+            Assert.That(() => a.CompareTo("a string"), Throws.Exception.TypeOf<System.ArgumentException>());
+            Assert.IsTrue(a < b);
+            Assert.IsTrue(a <= b);
+            Assert.IsFalse(a >= b);
+            Assert.IsFalse(a > b);
+            Assert.IsTrue((FbxTime)null < b);
+            Assert.IsFalse(a < (FbxTime)null);
+            Assert.IsFalse((FbxTime)null < (FbxTime)null);
+        }
+
+        [Test]
         public void TestBasics ()
         {
             // try the static functions


### PR DESCRIPTION
Define comparison operators for time.

Passes tests and coverage (except CurveAnimDef.Dispose(), not related).

Improved comments in equality.i (that's for @inwoods )

Improved equality testing (verify that Equals(object) doesn't throw when the
object is the wrong class).