### PR TITLE
build broken due to ignored build files in source directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,13 +16,6 @@ spike/2016.0/
 # swig output files
 *_wrap.cxx
 
-# cmake
-CMakeCache.txt
-CMakeFiles/
-Makefile
-
-build/
-
 # vim temp files
 *.swp
 *.swo


### PR DESCRIPTION
.gitignore was hiding these files and I thought the master was clean.

```
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   .gitignore

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	CMakeCache.txt
	CMakeFiles/
	CTestTestfile.cmake
	Makefile
	cmake_install.cmake
	spike/Makefile
```