### PR TITLE
UNI-18042 Clean up the AnimCurve support.

### DIFF
--- a/src/fbxanimcurve.i
+++ b/src/fbxanimcurve.i
@@ -8,6 +8,20 @@
 // Unignore class
 %rename("%s", %$isclass) FbxAnimCurve;
 
+// Create is funny: you *only* get the form with an FbxScene.
+// The base class defined Create with the other arguments,
+// make them throw (they return null in C++).
+%ignore FbxAnimCurve::Create(FbxManager*, const char*);
+%rename("%s") FbxAnimCurve::Create(FbxScene*, const char*);
+%extend FbxAnimCurve { %proxycode %{
+  public static new FbxAnimCurve Create(FbxManager pManager, string pName) {
+    throw new System.NotImplementedException("FbxAnimCurve can only be created with a scene as argument.");
+  }
+  public static new FbxAnimCurve Create(FbxObject pContainer, string pName) {
+    throw new System.NotImplementedException("FbxAnimCurve can only be created with a scene as argument.");
+  }
+%} }
+
 // As the ignore everything will include the constructor, destructor, methods etc
 // in the class, these have to be explicitly unignored too:
 %rename("%s") FbxAnimCurve::KeyModifyBegin;
@@ -21,7 +35,7 @@
         FbxTime pTime,
         float pValue,
         FbxAnimCurveDef::EInterpolationType pInterpolation=FbxAnimCurveDef::eInterpolationCubic,
-		FbxAnimCurveDef::ETangentMode pTangentMode=FbxAnimCurveDef::eTangentAuto,
+        FbxAnimCurveDef::ETangentMode pTangentMode=FbxAnimCurveDef::eTangentAuto,
         float pData0=0.0,
         float pData1=0.0,
         FbxAnimCurveDef::EWeightedMode pTangentWeightMode=FbxAnimCurveDef::eWeightedNone,
@@ -38,7 +52,17 @@
 %rename("%s") FbxAnimCurveDef::EInterpolationType;
 %rename("%s") FbxAnimCurveDef::ETangentMode;
 %rename("%s") FbxAnimCurveDef::EWeightedMode;
-%rename("%s") FbxAnimCurveDef::sDEFAULT_WEIGHT;
-%rename("%s") FbxAnimCurveDef::sDEFAULT_VELOCITY;
+%fbximmutable(FbxAnimCurveDef::sDEFAULT_WEIGHT);
+%fbximmutable(FbxAnimCurveDef::sDEFAULT_VELOCITY);
+%fbximmutable(FbxAnimCurveDef::sMIN_WEIGHT);
+%fbximmutable(FbxAnimCurveDef::sMAX_WEIGHT);
+
+// FbxAnimCurveDef is a static class. Take out all the standard cruft; we don't
+// need it. We use the method modifiers to comment out the Dispose function.
+%typemap(csclassmodifiers) FbxAnimCurveDef "public static class";
+%typemap(csinterfaces) FbxAnimCurveDef "";
+%typemap(csbody) FbxAnimCurveDef %{ %}
+%typemap(csdestruct, methodname="Dispose", methodmodifiers="//") FbxAnimCurveDef %{ { } %}
+%typemap(csfinalize) FbxAnimCurveDef %{ %}
 
 %include "fbxsdk/scene/animation/fbxanimcurve.h"

--- a/src/fbxanimcurvebase.i
+++ b/src/fbxanimcurvebase.i
@@ -5,11 +5,20 @@
 // See LICENSE.md file in the project root for full license information.
 // ***********************************************************************
 
-// Unignore class
+// Unignore class... but nothing in it.
 %rename("%s", %$isclass) FbxAnimCurveBase;
 
-// As the ignore everything will include the constructor, destructor, methods etc
-// in the class, these have to be explicitly unignored too:
-%rename("%s") FbxAnimCurveBase::Create;
+// FbxAnimCurveBase is abstract, so you can't create it.
+// Throw exceptions if we try.
+%ignore FbxAnimCurveBase::Create(FbxManager*, const char*);
+%ignore FbxAnimCurveBase::Create(FbxObject*, const char*);
+%extend FbxAnimCurveBase { %proxycode %{
+  public static new FbxAnimCurveBase Create(FbxManager pManager, string pName) {
+    throw new System.NotImplementedException("FbxAnimCurveBase is abstract; create FbxAnimCurve instead");
+  }
+  public static new FbxAnimCurveBase Create(FbxObject pContainer, string pName) {
+    throw new System.NotImplementedException("FbxAnimCurveBase is abstract; create FbxAnimCurve instead");
+  }
+%} }
 
 %include "fbxsdk/scene/animation/fbxanimcurvebase.h"

--- a/tests/UnityTests/Assets/Editor/UnitTests/Base.cs
+++ b/tests/UnityTests/Assets/Editor/UnitTests/Base.cs
@@ -357,7 +357,12 @@ namespace UnitTests
                     Assert.IsTrue (result);
                     Assert.IsTrue (ownerObj.IsConnectedDstObject (obj));
                     Assert.AreEqual (origCount + 1, ownerObj.GetDstObjectCount ());
-                    Assert.AreEqual (obj, ownerObj.GetDstObject ());
+                    if (origCount == 0) {
+                        Assert.AreEqual (obj, ownerObj.GetDstObject ());
+                    } else {
+                        // FbxAnimCurve has the scene as a DstObject
+                        Assert.AreNotEqual (obj, ownerObj.GetDstObject ());
+                    }
                     Assert.AreEqual (obj, ownerObj.GetDstObject (origCount));
                     Assert.AreEqual (obj, ownerObj.FindDstObject ("obj"));
                     Assert.IsNull (ownerObj.FindDstObject ("obj", origCount+1));


### PR DESCRIPTION
AnimCurveBase.Create throws (both forms).

AnimCurve only has one non-standard create function; the other two throw.

AnimCurveDef is a static class; we no longer fail coverage.

Tests updated.