### PR TITLE
UNI-18042: mark FbxEmitter abstract.

### DIFF
--- a/src/fbxemitter.i
+++ b/src/fbxemitter.i
@@ -4,22 +4,23 @@
 // Licensed under the ##LICENSENAME##.
 // See LICENSE.md file in the project root for full license information.
 // ***********************************************************************
-#ifdef IGNORE_ALL_INCLUDE_SOME
-// Unignore class
-%rename("%s") FbxEmitter;
-%rename("%s") FbxEmitter::Destroy;
-%nodefaultctor FbxEmitter;
 
-#endif
+%rename("%s", %$isclass) FbxEmitter;
 
 /*
  * While FbxEmitter doesn't have a Destroy function, everything else whose
- * memory we manage does. So invent one. This way we can call Destroy on
- * anything we manage. Because it's listed as virtual here, the C# side
- * uses dynamic dispatch.
+ * memory we manage does. So invent one. This way we can call Destroy in
+ * the Dispose().
+ *
+ * FbxObject overrides this.
+ * If we reveal the other FbxEmitter subclass, we'll have to create a Destroy
+ * for it.
  */
-%extend FbxEmitter {
-  virtual void Destroy(bool recursive = false) { }
-}
+%extend FbxEmitter { %proxycode %{
+  public abstract void Destroy();
+  public abstract void Destroy(bool recursive);
+%} }
+
+%typemap(csclassmodifiers) FbxEmitter "public abstract class";
 
 %include "fbxsdk/core/fbxemitter.h"

--- a/src/fbxobject.i
+++ b/src/fbxobject.i
@@ -5,14 +5,16 @@
 // See LICENSE.md file in the project root for full license information.
 // ***********************************************************************
 
-#ifdef IGNORE_ALL_INCLUDE_SOME
-// Unignore chosen class 'FbxObject'
-%rename("%s") FbxObject;
+%rename("%s", %$isclass) FbxObject;
 
-// As the ignore everything will include the constructor, destructor, methods etc
-// in the class, these have to be explicitly unignored too:
 %rename("%s") FbxObject::Create;
+
+/* Destroy is marked abstract in C# FbxEmitter but non-virtual in C++
+ * FbxObject. Mark it override in C#. */
+%csmethodmodifiers FbxObject::Destroy "public override";
 %rename("%s") FbxObject::Destroy;
+
+
 %rename("%s") FbxObject::GetName;
 %rename("%s") FbxObject::SetName;
 %rename("%s") FbxObject::GetInitialName;
@@ -67,7 +69,6 @@
 %rename("%s") FbxObject::HasDefaultImplementation;
 %rename("%s") FbxObject::GetDefaultImplementation;
 %rename("%s") FbxObject::SetDefaultImplementation;
-#endif
 
 %extend FbxObject {
   %proxycode %{


### PR DESCRIPTION
FbxEmitter had a fake function, which was messy; now it's marked abstract
instead so we have semantic indication that the function doesn't exist.