### PR TITLE
UNI-18809 fix FbxTime unit test char error

### DIFF
--- a/src/fbxsdk.i
+++ b/src/fbxsdk.i
@@ -125,6 +125,20 @@
   }
 %}
 %enddef  
+
+/* In C++ chars are stored as a single byte, whereas in C#
+ * chars are stored as 2 bytes (16-bit unicode). To ensure that the
+ * char is correct in C#, we return it as a byte and then convert it back to
+ * a char in C#.
+ * In C# a byte is an 8-bit unsigned int.
+ */
+%typemap(imtype,
+         outattributes="[return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U8)]") 
+         char "byte";
+%typemap(csout, excode=SWIGEXCODE) char {
+    byte ret = $imcall;$excode
+    return System.Convert.ToChar(ret);
+  }
   
 /*
  * How to handle strings. Must be before the includes that actually include code.


### PR DESCRIPTION
Fix so that the FbxTime function returning a ":", actually gives a colon instead of a chinese character.

The problem was that a char in C++ is represented as an [8-bit ASCII](http://www.swig.org/Doc1.3/SWIG.html#SWIG_nn10), whereas in C# it is represented as a [16-bit Unicode character](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/char).

The fix was to first convert the char to a byte then back to a char in C#. Fix should work for any other function returning a char.
