### PR TITLE
UNI-19198 fix FbxLayerElementArrayTemplate GetAt crash

### DIFF
--- a/src/fbxlayer.i
+++ b/src/fbxlayer.i
@@ -141,7 +141,17 @@
 %ignore FbxLayerElementArray::mDataType;
 
 %rename("$ignore", "not" %$isconstructor, regextarget=1, fullname=1) "FbxLayerElementArrayTemplate::.*";
-%rename("%s") FbxLayerElementArrayTemplate::GetAt;
+
+%rename("%sUnchecked") FbxLayerElementArrayTemplate::GetAt;
+%csmethodmodifiers FbxLayerElementArrayTemplate::GetAt "private";
+%extend FbxLayerElementArrayTemplate { %proxycode %{
+   public $typemap(cstype, T) GetAt(int pIndex) { 
+      if (pIndex < 0 || pIndex >= GetCount()) { 
+        throw new System.IndexOutOfRangeException();
+      }
+      return GetAtUnchecked(pIndex);
+    }
+%} }
 
 %include "fbxsdk_csharp-fixed-headers/fbxlayer.h"
 

--- a/tests/UnityTests/Assets/Editor/UnitTests/FbxLayerElementArrayTestBase.cs
+++ b/tests/UnityTests/Assets/Editor/UnitTests/FbxLayerElementArrayTestBase.cs
@@ -128,12 +128,20 @@ namespace UnitTests
         [Test]
         public void TestGetAt()
         {
-            var layerElementArrayTemplate = CreateObject ();
+            var layerElementArrayTemplate = CreateObject (EFbxType.eFbxDouble2);
+
+            layerElementArrayTemplate.SetCount (1);
 
             // make sure doesn't crash
             GetAt (layerElementArrayTemplate, 0);
-            GetAt (layerElementArrayTemplate, int.MinValue);
-            GetAt (layerElementArrayTemplate, int.MaxValue);
+
+            Assert.That (() => {
+                GetAt (layerElementArrayTemplate, int.MinValue);
+            }, Throws.Exception.TypeOf<System.IndexOutOfRangeException> ());
+
+            Assert.That (() => {
+                GetAt (layerElementArrayTemplate, int.MaxValue);
+            }, Throws.Exception.TypeOf<System.IndexOutOfRangeException> ());
         }
     }
 
@@ -145,14 +153,12 @@ namespace UnitTests
     public class FbxLayerElementArrayTemplateFbxSurfaceMaterialTest :
         FbxLayerElementArrayTemplateTestBase<FbxLayerElementArrayTemplateFbxSurfaceMaterial,FbxSurfaceMaterial> {}
 
-    [Ignore("Calling GetAt() causes a crash")]
     public class FbxLayerElementArrayTemplateFbxVector2Test : 
         FbxLayerElementArrayTemplateTestBase<FbxLayerElementArrayTemplateFbxVector2,FbxVector2> {}
 
     public class FbxLayerElementArrayTemplateFbxVector4Test : 
         FbxLayerElementArrayTemplateTestBase<FbxLayerElementArrayTemplateFbxVector4,FbxVector4> {}
 
-    [Ignore("Calling GetAt() causes a crash")]
     public class FbxLayerElementArrayTemplateIntTest : 
         FbxLayerElementArrayTemplateTestBase<FbxLayerElementArrayTemplateInt,int> {}
 }


### PR DESCRIPTION
Add bounds checking to GetAt.
Also set the EFbxType to FbxDouble2 (otherwise FbxVector2 template still
crashes)