### PR TITLE
remove duplicated functions from FbxProperty

### DIFF
--- a/src/fbxproperty.i
+++ b/src/fbxproperty.i
@@ -141,15 +141,6 @@
 %rename("%s") FbxProperty::GetInt;
 %rename("%s") FbxProperty::GetFbxColor;
 
-%extend FbxProperty{
-    int GetInt(){
-        return $self->Get<int>();
-    }
-    FbxColor GetFbxColor(){
-        return $self->Get<FbxColor>();
-    }
-}
-
 %extend FbxProperty {
     float GetFloat () const { return $self->Get<float>(); }
     FbxBool GetBool () const { return $self->Get<FbxBool>(); }


### PR DESCRIPTION
code accidentally got duplicated when merging the UNI-18847 lights
branch into the master