### PR TITLE
UNI-21193 - build to build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if (NOT DEFINED PACKAGE_VERSION)
 endif()
 
 if (NOT DEFINED PACKAGE_PATH)
-    set(PACKAGE_PATH "${CMAKE_SOURCE_DIR}/FbxSdk_${PACKAGE_VERSION}.unitypackage")
+    set(PACKAGE_PATH "${CMAKE_BINARY_DIR}/FbxSdk_${PACKAGE_VERSION}.unitypackage")
 endif()
 
 project (fbxsdk_csharp)


### PR DESCRIPTION
Is this a feature or a bug? We shouldn't normally be putting any build artifacts into the source directory.