### PR TITLE
Unity on MacOs requires bundles for libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,9 @@ swig_link_libraries(fbxsdk_csharp ${FBXSDK_LIBRARY})
 
 # hide FBX symbols in case the target application also has a copy of FBX
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-  set_target_properties(fbxsdk_csharp PROPERTIES LINK_FLAGS "-exported_symbols_list ${CMAKE_SOURCE_DIR}/deps/exported_symbols.txt")
+  set_target_properties(fbxsdk_csharp PROPERTIES
+  LINK_FLAGS "-exported_symbols_list ${CMAKE_SOURCE_DIR}/deps/exported_symbols.txt"
+  BUNDLE TRUE)
 endif()
 
 ###########################################################################

--- a/src/fbxsdk.i
+++ b/src/fbxsdk.i
@@ -157,13 +157,7 @@
   
   
 %pragma(csharp) imclasscode=%{
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-  private const string LIBRARY_NAME = "Assets/FbxSdk/Plugins/x64/MacOS/libfbxsdk_csharp.so";
-#elif UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
-  private const string LIBRARY_NAME = "Assets/FbxSdk/Plugins/x64/Linux/libfbxsdk_csharp.so";
-#else
   private const string LIBRARY_NAME = "fbxsdk_csharp";
-#endif
 %}
   
 /*


### PR DESCRIPTION
don't know why we didn't try this before...cannot remember...

https://forum.unity3d.com/threads/unity-dllnotfoundexception-when-adding-so-plugins.379721/