### PR TITLE
Uni-48530-Renamed_GlobalsPInvoke_to_NativeMethods_in_order_to_comply_with_FDG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ swig_add_library(UnityFbxSdkNative
 
 fbxsharp_run_python_postbuild(TARGET UnityFbxSdkNative
         SCRIPT ${CMAKE_SOURCE_DIR}/scripts/replace-dllimport.py
-        ARGS ${CMAKE_BINARY_DIR}/swig/generated/csharp/GlobalsPINVOKE.cs)
+        ARGS ${CMAKE_BINARY_DIR}/swig/generated/csharp/NativeMethods.cs)
 
 swig_link_libraries(UnityFbxSdkNative ${FBXSDK_LIBRARY})
 

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -877,7 +877,7 @@ RECURSIVE              = NO
 # run.
 
 EXCLUDE                = \
-                         @CMAKE_BINARY_DIR@/swig/generated/csharp/GlobalsPINVOKE.cs
+                         @CMAKE_BINARY_DIR@/swig/generated/csharp/NativeMethods.cs
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/examples/runtime/ProjectSettings/EditorBuildSettings.asset
+++ b/examples/runtime/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,6 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/ballsOnAPlane.unity
-    guid: addaff7dc7f335740844af0bd2230f4b
+    path: Assets/runtimeFbxSdk.unity
+    guid: 1e6d36210f07f1f44a5b827d06470618
   m_configObjects: {}

--- a/examples/runtime/ProjectSettings/ProjectVersion.txt
+++ b/examples/runtime/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.2.0b4
+m_EditorVersion: 2018.2.0b5

--- a/src/FbxSharpObjectLifetime.i
+++ b/src/FbxSharpObjectLifetime.i
@@ -173,7 +173,7 @@ extern "C" SWIGEXPORT int SWIGSTDCALL CSharp_$module_InitFbxAllocators() {
         Destroy();
       }
       lock(this) {
-        $modulePINVOKE.ReleaseWeakPointerHandle(swigCPtr);
+        $imclassname.ReleaseWeakPointerHandle(swigCPtr);
         swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
       }
     }

--- a/src/fbxsdk.i
+++ b/src/fbxsdk.i
@@ -4,6 +4,12 @@
 // Licensed under the ##LICENSENAME##.
 // See LICENSE.md file in the project root for full license information.
 // ***********************************************************************
+/* In order to comply to the FDG, we want the intermediary class to be named NativeMethods (not GlobalsPInvoke)
+ * https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/index
+ * https://msdn.microsoft.com/library/ms182161.aspx
+ */
+%module (imclassname="NativeMethods") Globals
+
 %module(directors="1") Globals
 %{
 #include "fbxsdk.h"

--- a/tests/UnityTests/Assets/Editor/UnitTests/GlobalsTest.cs
+++ b/tests/UnityTests/Assets/Editor/UnitTests/GlobalsTest.cs
@@ -13,7 +13,7 @@ namespace UnityEngine.Formats.FbxSdk.UnitTests
 {
     public class GlobalsTest
     {
-        const string kPINVOKE = "GlobalsPINVOKE";
+        const string kPINVOKE = "NativeMethods";
         static System.Type s_PINVOKEtype;
         static ConstructorInfo s_PINVOKEctor;
         static List<MethodInfo> s_UpcastFunctions = new List<MethodInfo>();
@@ -107,7 +107,7 @@ namespace UnityEngine.Formats.FbxSdk.UnitTests
              * static, so the coverage tests want us to create them. */
             new Globals();
 
-            /* Create the GlobalsPINVOKE, which isn't static.
+            /* Create the NativeMethods, which isn't static.
              * But it is protected, so we can't create it normally,
              * which is why we use reflection. */
             s_PINVOKEctor.Invoke(null);

--- a/tests/UnityTests/Assets/Editor/UseCaseTests/EditorDependancyTest.cs
+++ b/tests/UnityTests/Assets/Editor/UseCaseTests/EditorDependancyTest.cs
@@ -74,7 +74,7 @@ namespace UnityEngine.Formats.FbxSdk.UseCaseTests{
             Assert.IsNotEmpty (errorString);
             Assert.IsTrue (errorString.Contains (
                 "Unhandled Exception: System.TypeInitializationException: " +
-                "The type initializer for 'UnityEngine.Formats.FbxSdk.GlobalsPINVOKE' threw an exception"));
+                "The type initializer for 'UnityEngine.Formats.FbxSdk.NativeMethods' threw an exception"));
             Assert.IsTrue (errorString.Contains ("InitFbxAllocators"));
         }
     }


### PR DESCRIPTION
Uni-48530-Renamed_GlobalsPInvoke_to_NativeMethods_in_order_to_comply_with_FDG

All tests passed (in the 2 projects)