### PR TITLE
Reveal FbxLimits, and access to S/R/T limits on FbxNode.

### DIFF
--- a/Source/fbxnode.i
+++ b/Source/fbxnode.i
@@ -67,6 +67,18 @@
 %rename("%s") FbxNode::SetScalingOffset;
 %rename("%s") FbxNode::GetScalingPivot;
 %rename("%s") FbxNode::SetScalingPivot;
+
+// Limits (returns by ref; there's no corresponding set)
+// Note: swig doesn't see these functions, so we need to redefine them.
+// (order matters: rename first, extend after)
+%rename("%s") FbxNode::GetTranslationLimits;
+%rename("%s") FbxNode::GetRotationLimits;
+%rename("%s") FbxNode::GetScalingLimits;
+%extend FbxNode {
+  FbxLimits& GetTranslationLimits() { return self->GetTranslationLimits(); }
+  FbxLimits& GetRotationLimits() { return self->GetRotationLimits(); }
+  FbxLimits& GetScalingLimits() { return self->GetScalingLimits(); }
+}
 #endif
 
 /* The properties need to be marked immutable. */

--- a/Source/fbxsdk.i
+++ b/Source/fbxsdk.i
@@ -253,6 +253,7 @@
 %include "fbxstatus.i"
 %include "fbxquaternion.i"
 %include "fbxprogress.i"
+%include "fbxtransforms.i"
 
 /* The emitter hierarchy. Must be in partial order (base class before derived class). */
 %include "fbxemitter.i"
@@ -298,5 +299,4 @@
 %include "fbxblendshapechannel.i"
 %include "fbxshape.i"
 %include "fbxio.i"
-%include "fbxtransforms.i"
 %include "fbxconstraint.i"

--- a/Source/fbxtransforms.i
+++ b/Source/fbxtransforms.i
@@ -5,8 +5,48 @@
 // See LICENSE.md file in the project root for full license information.
 // ***********************************************************************
 
+// FbxTransform
 %rename("%s", %$isclass) FbxTransform;
 %declare_static_class(FbxTransform);
 %rename("%s") FbxTransform::EInheritType;
+
+
+// FbxLimits
+// This is a simple class that you can use independently of anything.
+// Not likely to be important to optimize but it would be easy to reimplement
+// it in C# and avoid the extra allocation.
+%rename("%s", %$isclass) FbxLimits;
+%rename("%s") FbxLimits::FbxLimits;
+%rename("%s") FbxLimits::~FbxLimits;
+
+// Optimization potential: grab the mMask directly to get/set the active status
+// all in one P/Invoke (rather than 7).
+//
+// Note: Not exposing GetMinActive/GetMaxActive because then we need to deal
+// with ref arguments.
+%rename("%s") FbxLimits::GetActive;
+%rename("%s") FbxLimits::GetMinXActive;
+%rename("%s") FbxLimits::GetMinYActive;
+%rename("%s") FbxLimits::GetMinZActive;
+%rename("%s") FbxLimits::GetMaxXActive;
+%rename("%s") FbxLimits::GetMaxYActive;
+%rename("%s") FbxLimits::GetMaxZActive;
+%rename("%s") FbxLimits::GetMin;
+%rename("%s") FbxLimits::GetMax;
+
+%rename("%s") FbxLimits::SetActive;
+%rename("%s") FbxLimits::SetMinActive;
+%rename("%s") FbxLimits::SetMinXActive;
+%rename("%s") FbxLimits::SetMinYActive;
+%rename("%s") FbxLimits::SetMinZActive;
+%rename("%s") FbxLimits::SetMaxActive;
+%rename("%s") FbxLimits::SetMaxXActive;
+%rename("%s") FbxLimits::SetMaxYActive;
+%rename("%s") FbxLimits::SetMaxZActive;
+%rename("%s") FbxLimits::SetMin;
+%rename("%s") FbxLimits::SetMax;
+
+%rename("%s") FbxLimits::GetAnyMinMaxActive;
+%rename("%s") FbxLimits::Apply;
 
 %include "fbxsdk/core/math/fbxtransforms.h"

--- a/TestProjects/FbxSDK/Assets/Editor/UnitTests/FbxLimitsTest.cs
+++ b/TestProjects/FbxSDK/Assets/Editor/UnitTests/FbxLimitsTest.cs
@@ -1,0 +1,57 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Unity Technologies. All rights reserved.
+//
+// Licensed under the ##LICENSENAME##.
+// See LICENSE.md file in the project root for full license information.
+// ***********************************************************************
+
+using NUnit.Framework;
+using System.Collections;
+using Autodesk.Fbx;
+
+namespace Autodesk.Fbx.UnitTests
+{
+    public class FbxLimitsTest : TestBase<FbxLimits>
+    {
+        // There's lots of flags with get/set to test. Do it with lambdas.
+        delegate bool GetActive();
+        delegate void SetActive(bool active);
+        void AssertActiveFlag(GetActive getActive, SetActive setActive)
+        {
+            Assert.IsFalse(getActive());
+            setActive(true);
+            Assert.IsTrue(getActive());
+        }
+
+        [Test]
+        public void TestBasics ()
+        {
+            var limits = new FbxLimits();
+
+            AssertActiveFlag(limits.GetActive, limits.SetActive);
+
+            AssertActiveFlag(limits.GetMinXActive, limits.SetMinXActive);
+            AssertActiveFlag(limits.GetMinYActive, limits.SetMinYActive);
+            AssertActiveFlag(limits.GetMinZActive, limits.SetMinZActive);
+            limits.SetMin(new FbxDouble3(1, 2, 3));
+            Assert.That(limits.GetMin(), Is.EqualTo(new FbxDouble3(1, 2, 3)));
+
+            AssertActiveFlag(limits.GetMaxXActive, limits.SetMaxXActive);
+            AssertActiveFlag(limits.GetMaxYActive, limits.SetMaxYActive);
+            AssertActiveFlag(limits.GetMaxZActive, limits.SetMaxZActive);
+            limits.SetMax(new FbxDouble3(4, 5, 6));
+            Assert.That(limits.GetMax(), Is.EqualTo(new FbxDouble3(4, 5, 6)));
+
+            Assert.That(limits.Apply(new FbxDouble3(7, 8, 9)), Is.EqualTo(new FbxDouble3(4, 5, 6)));
+
+            limits.SetMinActive(false, true, false);
+            Assert.IsFalse(limits.GetMinXActive());
+            Assert.IsTrue(limits.GetMinYActive());
+            limits.SetMaxActive(false, false, false);
+            Assert.IsFalse(limits.GetMaxXActive());
+            Assert.IsTrue(limits.GetAnyMinMaxActive());
+
+            limits.Dispose();
+        }
+    }
+}

--- a/TestProjects/FbxSDK/Assets/Editor/UnitTests/FbxLimitsTest.cs.meta
+++ b/TestProjects/FbxSDK/Assets/Editor/UnitTests/FbxLimitsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8ecadb3c4ad347be97985b7640beb08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/FbxSDK/Assets/Editor/UnitTests/FbxNodeTest.cs
+++ b/TestProjects/FbxSDK/Assets/Editor/UnitTests/FbxNodeTest.cs
@@ -125,6 +125,16 @@ namespace Autodesk.Fbx.UnitTests
             Assert.IsNull(fooNode.GetNodeAttribute());
             Assert.IsNull(fooNode.GetSkeleton());
             Assert.IsNull (fooNode.GetLight ());
+
+            // Test that we can get at the limits by reference.
+            Assert.IsNotNull(fooNode.GetTranslationLimits());
+            Assert.IsNotNull(fooNode.GetRotationLimits());
+            Assert.IsNotNull(fooNode.GetScalingLimits());
+
+            var limits = fooNode.GetTranslationLimits();
+            Assert.IsFalse(limits.GetActive());
+            limits.SetActive(true);
+            Assert.IsTrue(fooNode.GetTranslationLimits().GetActive());
         }
 
         [Test]


### PR DESCRIPTION
Turns out these are only used in MoBu and Maya -- not Max or Unity.