### PR TITLE
add FbxMesh binding for GetPolygonVertexNormal

### DIFF
--- a/Source/fbxmesh.i
+++ b/Source/fbxmesh.i
@@ -15,6 +15,9 @@
 %rename("%s") FbxMesh::GetPolygonSize;
 %rename("%s") FbxMesh::GetPolygonVertexCount;
 
+%apply FbxVector4& OUTPUT { FbxVector4& pNormal };
+%rename("%s") FbxMesh::GetPolygonVertexNormal(int pPolyIndex, int pVertexIndex, FbxVector4& pNormal) const;
+
 #endif
 
 /*

--- a/tests/RuntimeTests/Editor/UnitTests/FbxMeshTest.cs
+++ b/tests/RuntimeTests/Editor/UnitTests/FbxMeshTest.cs
@@ -8,6 +8,7 @@
 using NUnit.Framework;
 using System.Collections;
 using Autodesk.Fbx;
+using UnityEngine.TestTools.Utils;
 
 namespace Autodesk.Fbx.UnitTests
 {
@@ -85,6 +86,82 @@ namespace Autodesk.Fbx.UnitTests
                 Assert.AreEqual (mesh.GetPolygonVertex (polyCount - 1, 0), 0);
                 Assert.AreEqual ( mesh.GetPolygonVertexCount (), polyVertexCount);
                 Assert.AreEqual (mesh.GetPolygonCount (), polyCount);
+            }
+        }
+
+        [Test]
+        public void TestGetPolygonVertexNormal() {
+            using (FbxMesh mesh = CreateObject("mesh")) {
+                mesh.InitControlPoints(4);
+                mesh.SetControlPointAt(new FbxVector4(0, 0, 0), 0);
+                mesh.SetControlPointAt(new FbxVector4(1, 0, 0), 1);
+                mesh.SetControlPointAt(new FbxVector4(1, 0, 1), 2);
+                mesh.SetControlPointAt(new FbxVector4(0, 0, 1), 3);
+
+                mesh.BeginPolygon();
+                mesh.AddPolygon(0);
+                mesh.AddPolygon(1);
+                mesh.AddPolygon(2);
+                mesh.AddPolygon(3);
+                mesh.EndPolygon();
+
+                // Add normals to the mesh
+                FbxVector4 normal0 = new FbxVector4(0, 0, 1);
+                FbxVector4 normal1 = new FbxVector4(0, 1, 0);
+                FbxVector4 normal2 = new FbxVector4(0, 1, 1);
+                FbxVector4 normal3 = new FbxVector4(0.301511344577764d, 0.904534033733291d, 0.301511344577764d);
+
+                using (var fbxLayerElement = FbxLayerElementNormal.Create(mesh, "Normals")) {
+                    // Set the Normals on the default layer
+                    FbxLayer fbxLayer = mesh.GetLayer(0);
+                    if (fbxLayer == null) {
+                        mesh.CreateLayer();
+                        fbxLayer = mesh.GetLayer(0);
+                    }
+
+                    fbxLayerElement.SetMappingMode(FbxLayerElement.EMappingMode.eByControlPoint);
+                    fbxLayerElement.SetReferenceMode(FbxLayerElement.EReferenceMode.eDirect);
+                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray();
+
+                    fbxElementArray.Add(normal0);
+                    fbxElementArray.Add(normal1);
+                    fbxElementArray.Add(normal2);
+                    fbxElementArray.Add(normal3);
+
+                    fbxLayer.SetNormals(fbxLayerElement);
+                }
+
+                FbxVector4 readNormal0; 
+                FbxVector4 readNormal1; 
+                FbxVector4 readNormal2;
+                FbxVector4 readNormal3;
+
+                // test if all normals can be read
+                Assert.IsTrue(mesh.GetPolygonVertexNormal(0, 0, out readNormal0));
+                Assert.IsTrue(mesh.GetPolygonVertexNormal(0, 1, out readNormal1));
+                Assert.IsTrue(mesh.GetPolygonVertexNormal(0, 2, out readNormal2));
+                Assert.IsTrue(mesh.GetPolygonVertexNormal(0, 3, out readNormal3));
+
+                // test if the normals have the correct values
+                Assert.That(normal0.X, Is.EqualTo(readNormal0.X).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal0.Y, Is.EqualTo(readNormal0.Y).Using(FloatEqualityComparer.Instance));                
+                Assert.That(normal0.Z, Is.EqualTo(readNormal0.Z).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal0.W, Is.EqualTo(readNormal0.W).Using(FloatEqualityComparer.Instance));
+
+                Assert.That(normal1.X, Is.EqualTo(readNormal1.X).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal1.Y, Is.EqualTo(readNormal1.Y).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal1.Z, Is.EqualTo(readNormal1.Z).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal1.W, Is.EqualTo(readNormal1.W).Using(FloatEqualityComparer.Instance));
+
+                Assert.That(normal2.X, Is.EqualTo(readNormal2.X).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal2.Y, Is.EqualTo(readNormal2.Y).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal2.Z, Is.EqualTo(readNormal2.Z).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal2.W, Is.EqualTo(readNormal2.W).Using(FloatEqualityComparer.Instance));
+
+                Assert.That(normal3.X, Is.EqualTo(readNormal3.X).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal3.Y, Is.EqualTo(readNormal3.Y).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal3.Z, Is.EqualTo(readNormal3.Z).Using(FloatEqualityComparer.Instance));
+                Assert.That(normal3.W, Is.EqualTo(readNormal3.W).Using(FloatEqualityComparer.Instance));
             }
         }
 


### PR DESCRIPTION
This PR exposes the function FbxMesh::GetPolygonVertexNormal()

I used a typemap for the out parameter that returns the normal. Without doing that, swig would generate a SWIGTYPE_p_FbxVector4 instead of using the dedicated optimized struct. Not sure if that's how it's intended to be used.

For the unit test I currently use FloatEqualityComparers to check if the normals that are read back, are approximately equal to the ones that were set. This is a bit verbose as you can see.
Some ideas for improvement:
- Unity's Vector3 class overrides the == operator so that it does approximate comparison. The same might make sense to do with FbxVector4s (and of course FbxVector2s) as well.
- One could write a dedicated IEqualityComparer for FbxVector structs that does approximate comparison [like the ones Unity provides](https://docs.unity3d.com/2019.1/Documentation/ScriptReference/TestTools.Utils.Vector3EqualityComparer.html) for some of their structs.

Let me know if you think there should be any changes.