### PR TITLE
Ut 3782/fix tests failing on il2cpp

### DIFF
--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -28,6 +28,7 @@ editors:
   - version: 2019.4
   - version: 2020.1
 backends:
+  - name: mono
   - name: il2cpp
 mac_platform:
   name: mac

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -160,9 +160,10 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% if editor.version == 2018.4 and platform.name == "ubuntu" %}
     # There is no IL2CPP on Ubuntu before 2019.3
     - upm-ci package test --backend mono --unity-version {{ editor.version }} --package-path com.autodesk.fbx
-{% else if editor.version == 2018.4 %}
+{% elseif editor.version == 2018.4 %}
     {% if platform.name == "ubuntu" %}
-    - sudo apt-get install clang-6.0
+    # clang required for il2cpp backend
+    - sudo apt-get -y install clang
     {% endif %}
     - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% else %}

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -27,8 +27,6 @@ editors:
   - version: 2018.4
   - version: 2019.4
   - version: 2020.1
-backends:
-  - name: il2cpp
 mac_platform:
   name: mac
   type: Unity::VM::osx
@@ -146,12 +144,9 @@ pack:
         - "com.autodesk.fbx/**"
 
 {% for editor in editors %}
-{% for backend in backends %}
 {% for platform in platforms %}
-# There is no IL2CPP on Ubuntu before 2019.3
-{% unless platform.name == "ubuntu" and editor.version == 2018.4 and backend.name == "il2cpp" %}
-test_{{ platform.name }}_{{ editor.version }}_{{ backend.name }}:
-  name : Test version {{ editor.version }} {{ backend.name }} on {{ platform.name }}
+test_{{ platform.name }}_{{ editor.version }}:
+  name : Test version {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}
@@ -163,13 +158,18 @@ test_{{ platform.name }}_{{ editor.version }}_{{ backend.name }}:
   commands:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
 # Code coverage is only available in Unity 2019.3 and higher
-{% if editor.version == 2018.4 %}
-    - upm-ci package test --extra-utr-arg="--scripting-backend={{backend.name}}" --unity-version {{ editor.version }} --package-path com.autodesk.fbx
+{% if editor.version == 2018.4 and platform.name == "ubuntu" %}
+    # There is no IL2CPP on Ubuntu before 2019.3
+    - upm-ci package test --backend mono --unity-version {{ editor.version }} --package-path com.autodesk.fbx
+{% else if editor.version == 2018.4 %}
+    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx
+    - upm-ci package test --backend il2cpp --platform standalone --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% else %}
-    - upm-ci package test --extra-utr-arg="--scripting-backend={{backend.name}}" --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
+    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
+    - upm-ci package test --backend il2cpp --platform standalone --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
 {% endif %}
-    - echo "****** PASSED {{ backend.name }} backend *******"
+    - echo "****** PASSED *******"
   triggers:
     pull_requests:
       - targets:
@@ -184,8 +184,6 @@ test_{{ platform.name }}_{{ editor.version }}_{{ backend.name }}:
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/yamato.yml#pack
-{% endunless %}
-{% endfor %}
 {% endfor %}
 {% endfor %}
 
@@ -234,12 +232,7 @@ publish:
     - .yamato/yamato.yml#pack
 {% for editor in editors %}
 {% for platform in platforms %}
-{% for backend in backends %}
-# There is no IL2CPP on Ubuntu before 2019.3
-{% unless platform.name == "ubuntu" and editor.version == 2018.4 and backend.name == "il2cpp" %}
-    - .yamato/yamato.yml#test_{{ platform.name }}_{{ editor.version }}_{{ backend.name }}
-{% endunless %}
-{% endfor %}
+    - .yamato/yamato.yml#test_{{ platform.name }}_{{ editor.version }}
 {% endfor %}
 {% endfor %}
 

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -106,7 +106,7 @@ build_ubuntu:
     image: {{ ubuntu_platform.image }}
     flavor: {{ ubuntu_platform.flavor}}
   commands:
-    - sudo apt-get install p7zip mono-devel clang
+    - sudo apt-get install p7zip mono-devel
     - python ./build.py --stevedore --verbose --clean --yamato
     - mv build build-ubuntu
   artifacts:
@@ -161,6 +161,9 @@ test_{{ platform.name }}_{{ editor.version }}:
     # There is no IL2CPP on Ubuntu before 2019.3
     - upm-ci package test --backend mono --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% else if editor.version == 2018.4 %}
+    {% if platform.name == "ubuntu" %}
+    - sudo apt-get install clang-6.0
+    {% endif %}
     - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% else %}
     # Code coverage is only available in Unity 2019.3 and higher

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -161,12 +161,12 @@ test_{{ platform.name }}_{{ editor.version }}:
     # There is no IL2CPP on Ubuntu before 2019.3
     - upm-ci package test --backend mono --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% elseif editor.version == 2018.4 %}
+    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx
+{% else %}
     {% if platform.name == "ubuntu" %}
     # clang required for il2cpp backend
     - sudo apt-get -y install clang
     {% endif %}
-    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx
-{% else %}
     # Code coverage is only available in Unity 2019.3 and higher
     - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -27,9 +27,6 @@ editors:
   - version: 2018.4
   - version: 2019.4
   - version: 2020.1
-test_platforms:
-  - name: standalone
-  - name: editmode
 mac_platform:
   name: mac
   type: Unity::VM::osx
@@ -109,7 +106,7 @@ build_ubuntu:
     image: {{ ubuntu_platform.image }}
     flavor: {{ ubuntu_platform.flavor}}
   commands:
-    - sudo apt-get install p7zip mono-devel
+    - sudo apt-get install p7zip mono-devel clang
     - python ./build.py --stevedore --verbose --clean --yamato
     - mv build build-ubuntu
   artifacts:
@@ -148,9 +145,8 @@ pack:
 
 {% for editor in editors %}
 {% for platform in platforms %}
-{% for test_platform in test_platforms %}
-test_{{ platform.name }}_{{ editor.version }}_{{ test_platform.name }}:
-  name : Test version {{ editor.version }} on {{ platform.name }} in {{ test_platform.name }}
+test_{{ platform.name }}_{{ editor.version }}:
+  name : Test version {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}
@@ -163,15 +159,15 @@ test_{{ platform.name }}_{{ editor.version }}_{{ test_platform.name }}:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
 {% if editor.version == 2018.4 and platform.name == "ubuntu" %}
     # There is no IL2CPP on Ubuntu before 2019.3
-    - upm-ci package test --backend mono --platform {{ test_platform.name }} --unity-version {{ editor.version }} --package-path com.autodesk.fbx   
+    - upm-ci package test --backend mono --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% else if editor.version == 2018.4 %}
-    # Code coverage is only available in Unity 2019.3 and higher
-    - upm-ci package test --backend il2cpp --platform {{ test_platform.name }} --unity-version {{ editor.version }} --package-path com.autodesk.fbx
+    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% else %}
-    - upm-ci package test --backend il2cpp --platform {{ test_platform.name }} --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
+    # Code coverage is only available in Unity 2019.3 and higher
+    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
 {% endif %}
-    - echo "****** PASSED {{ test_platform.name }} Tests *******"
+    - echo "****** PASSED *******"
   triggers:
     pull_requests:
       - targets:
@@ -186,7 +182,6 @@ test_{{ platform.name }}_{{ editor.version }}_{{ test_platform.name }}:
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/yamato.yml#pack
-{% endfor %}
 {% endfor %}
 {% endfor %}
 
@@ -235,9 +230,7 @@ publish:
     - .yamato/yamato.yml#pack
 {% for editor in editors %}
 {% for platform in platforms %}
-{% for test_platform in test_platforms %}
-    - .yamato/yamato.yml#test_{{ platform.name }}_{{ editor.version }}_{{ test_platform.name }}
-{% endfor %}
+    - .yamato/yamato.yml#test_{{ platform.name }}_{{ editor.version }}
 {% endfor %}
 {% endfor %}
 

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -28,7 +28,6 @@ editors:
   - version: 2019.4
   - version: 2020.1
 backends:
-  - name: mono
   - name: il2cpp
 mac_platform:
   name: mac

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -27,6 +27,9 @@ editors:
   - version: 2018.4
   - version: 2019.4
   - version: 2020.1
+test_platforms:
+  - name: standalone
+  - name: editmode
 mac_platform:
   name: mac
   type: Unity::VM::osx
@@ -145,8 +148,9 @@ pack:
 
 {% for editor in editors %}
 {% for platform in platforms %}
-test_{{ platform.name }}_{{ editor.version }}:
-  name : Test version {{ editor.version }} on {{ platform.name }}
+{% for test_platform in test_platforms %}
+test_{{ platform.name }}_{{ editor.version }}_{{ test_platform.name }}:
+  name : Test version {{ editor.version }} on {{ platform.name }} in {{ test_platform.name }}
   agent:
     type: {{ platform.type }}
     image: {{ platform.image }}
@@ -157,19 +161,17 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% endif %}
   commands:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-# Code coverage is only available in Unity 2019.3 and higher
 {% if editor.version == 2018.4 and platform.name == "ubuntu" %}
     # There is no IL2CPP on Ubuntu before 2019.3
-    - upm-ci package test --backend mono --unity-version {{ editor.version }} --package-path com.autodesk.fbx
+    - upm-ci package test --backend mono --platform {{ test_platform.name }} --unity-version {{ editor.version }} --package-path com.autodesk.fbx   
 {% else if editor.version == 2018.4 %}
-    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx
-    - upm-ci package test --backend il2cpp --platform standalone --unity-version {{ editor.version }} --package-path com.autodesk.fbx
+    # Code coverage is only available in Unity 2019.3 and higher
+    - upm-ci package test --backend il2cpp --platform {{ test_platform.name }} --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% else %}
-    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
-    - upm-ci package test --backend il2cpp --platform standalone --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
+    - upm-ci package test --backend il2cpp --platform {{ test_platform.name }} --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
 {% endif %}
-    - echo "****** PASSED *******"
+    - echo "****** PASSED {{ test_platform.name }} Tests *******"
   triggers:
     pull_requests:
       - targets:
@@ -184,6 +186,7 @@ test_{{ platform.name }}_{{ editor.version }}:
         - "upm-ci~/test-results/**/*"
   dependencies:
     - .yamato/yamato.yml#pack
+{% endfor %}
 {% endfor %}
 {% endfor %}
 
@@ -232,7 +235,9 @@ publish:
     - .yamato/yamato.yml#pack
 {% for editor in editors %}
 {% for platform in platforms %}
-    - .yamato/yamato.yml#test_{{ platform.name }}_{{ editor.version }}
+{% for test_platform in test_platforms %}
+    - .yamato/yamato.yml#test_{{ platform.name }}_{{ editor.version }}_{{ test_platform.name }}
+{% endfor %}
 {% endfor %}
 {% endfor %}
 

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -161,13 +161,18 @@ test_{{ platform.name }}_{{ editor.version }}:
     # There is no IL2CPP on Ubuntu before 2019.3
     - upm-ci package test --backend mono --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% elseif editor.version == 2018.4 %}
+    # Setting backend to il2cpp to ensure il2cpp is installed.
+    # Note: setting backend to il2cpp will still run the tests with mono by default 
+    #       (would need to add --platform standalone to run playmode tests with il2cpp),
+    #       however this installs il2cpp so that the editor build tests can change the backend as necessary.
     - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% else %}
     {% if platform.name == "ubuntu" %}
     # clang required for il2cpp backend
     - sudo apt-get -y install clang
     {% endif %}
-    # Code coverage is only available in Unity 2019.3 and higher
+    # Code coverage is only available in Unity 2019.3 and higher.
+    # Setting backend to il2cpp to ensure il2cpp is installed and can be used by editor tests (see Note above).
     - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
 {% endif %}

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -165,9 +165,9 @@ test_{{ platform.name }}_{{ editor.version }}_{{ backend.name }}:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
 # Code coverage is only available in Unity 2019.3 and higher
 {% if editor.version == 2018.4 %}
-    - upm-ci package test --backend {{ backend.name }} --unity-version {{ editor.version }} --package-path com.autodesk.fbx
+    - upm-ci package test --extra-utr-arg="--scripting-backend={{backend.name}}" --unity-version {{ editor.version }} --package-path com.autodesk.fbx
 {% else %}
-    - upm-ci package test --backend {{ backend.name }} --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
+    - upm-ci package test --extra-utr-arg="--scripting-backend={{backend.name}}" --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
 {% endif %}
     - echo "****** PASSED {{ backend.name }} backend *******"

--- a/tests/RuntimeTests/Editor/BuildTests/BuildTest.cs
+++ b/tests/RuntimeTests/Editor/BuildTests/BuildTest.cs
@@ -49,10 +49,8 @@ namespace Autodesk.Fbx.BuildTests
         {
             get
             {
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol }, false, false).SetName("FbxSdkNotIncludedAtRuntime").Returns(null);
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol }, false, true).SetName("FbxSdkNotIncludedAtRuntime_IL2CPP").Returns(null);
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" }, true, false).SetName("FbxSdkIncludedAtRuntime").Returns(null);
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" }, true, true).SetName("FbxSdkIncludedAtRuntime_IL2CPP").Returns(null);
+                yield return new TestCaseData(new string[] { k_runningBuildSymbol }, false).SetName("FbxSdkNotIncludedAtRuntime").Returns(null);
+                yield return new TestCaseData(new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" }, true).SetName("FbxSdkIncludedAtRuntime").Returns(null);
             }
         }
 
@@ -71,9 +69,6 @@ namespace Autodesk.Fbx.BuildTests
             // remove the running build symbol and everything after it
             var result = symbols.Split(new string[] { k_runningBuildSymbol, ";" + k_runningBuildSymbol }, System.StringSplitOptions.None);
             PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, result[0]);
-
-            // set scripting backend back to default (Mono)
-            PlayerSettings.SetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup, ScriptingImplementation.Mono2x);
 
             // delete build folder
             if (Directory.Exists(BuildFolder))
@@ -120,13 +115,8 @@ namespace Autodesk.Fbx.BuildTests
 
         [UnityTest]
         [TestCaseSource("RuntimeFbxSdkTestData")]
-        public IEnumerator TestFbxSdkAtRuntime(string[] defineSymbols, bool dllExists, bool useIL2CPP)
+        public IEnumerator TestFbxSdkAtRuntime(string[] defineSymbols, bool dllExists)
         {
-            if (useIL2CPP)
-            {
-                PlayerSettings.SetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup, ScriptingImplementation.IL2CPP);
-            }
-
             AddDefineSymbols(defineSymbols);
 
             // start and stop playmode to force a domain reload

--- a/tests/RuntimeTests/Editor/BuildTests/BuildTest.cs
+++ b/tests/RuntimeTests/Editor/BuildTests/BuildTest.cs
@@ -49,8 +49,10 @@ namespace Autodesk.Fbx.BuildTests
         {
             get
             {
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol }, false).SetName("FbxSdkNotIncludedAtRuntime").Returns(null);
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" }, true).SetName("FbxSdkIncludedAtRuntime").Returns(null);
+                yield return new TestCaseData(new string[] { k_runningBuildSymbol }, false, false).SetName("FbxSdkNotIncludedAtRuntime").Returns(null);
+                yield return new TestCaseData(new string[] { k_runningBuildSymbol }, false, true).SetName("FbxSdkNotIncludedAtRuntime_IL2CPP").Returns(null);
+                yield return new TestCaseData(new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" }, true, false).SetName("FbxSdkIncludedAtRuntime").Returns(null);
+                yield return new TestCaseData(new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" }, true, true).SetName("FbxSdkIncludedAtRuntime_IL2CPP").Returns(null);
             }
         }
 
@@ -69,6 +71,9 @@ namespace Autodesk.Fbx.BuildTests
             // remove the running build symbol and everything after it
             var result = symbols.Split(new string[] { k_runningBuildSymbol, ";" + k_runningBuildSymbol }, System.StringSplitOptions.None);
             PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, result[0]);
+
+            // set scripting backend back to default (Mono)
+            PlayerSettings.SetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup, ScriptingImplementation.Mono2x);
 
             // delete build folder
             if (Directory.Exists(BuildFolder))
@@ -115,8 +120,13 @@ namespace Autodesk.Fbx.BuildTests
 
         [UnityTest]
         [TestCaseSource("RuntimeFbxSdkTestData")]
-        public IEnumerator TestFbxSdkAtRuntime(string[] defineSymbols, bool dllExists)
+        public IEnumerator TestFbxSdkAtRuntime(string[] defineSymbols, bool dllExists, bool useIL2CPP)
         {
+            if (useIL2CPP)
+            {
+                PlayerSettings.SetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup, ScriptingImplementation.IL2CPP);
+            }
+
             AddDefineSymbols(defineSymbols);
 
             // start and stop playmode to force a domain reload

--- a/tests/RuntimeTests/Editor/BuildTests/BuildTest.cs
+++ b/tests/RuntimeTests/Editor/BuildTests/BuildTest.cs
@@ -30,7 +30,8 @@ namespace Autodesk.Fbx.BuildTests
         private const BuildTarget k_buildTarget = BuildTarget.StandaloneLinux64;
         private const string k_autodeskDllInstallPath = "Managed";
 #endif
-        
+        private const BuildTargetGroup k_buildTargetGroup = BuildTargetGroup.Standalone;
+
         private const string k_buildTestScene = "Packages/com.autodesk.fbx/Tests/Runtime/BuildTestsAssets/BuildTestScene.unity";
 
         private const string k_createdFbx = "emptySceneFromRuntimeBuild.fbx";
@@ -49,12 +50,28 @@ namespace Autodesk.Fbx.BuildTests
         {
             get
             {
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol }, false, false).SetName("FbxSdkNotIncludedAtRuntime").Returns(null);
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" }, true, false).SetName("FbxSdkIncludedAtRuntime").Returns(null);
-                #if !UNITY_EDITOR_LINUX || UNITY_2019_3_OR_NEWER
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol }, false, true).SetName("FbxSdkNotIncludedAtRuntime_IL2CPP").Returns(null);
-                yield return new TestCaseData(new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" }, true, true).SetName("FbxSdkIncludedAtRuntime_IL2CPP").Returns(null);
-                #endif // !UNITY_EDITOR_LINUX || UNITY_2019_3_OR_NEWER
+                yield return new TestCaseData(
+                    new string[] { k_runningBuildSymbol }, 
+                    false,
+                    ScriptingImplementation.Mono2x
+                    ).SetName("FbxSdkNotIncludedAtRuntime_Mono").Returns(null);
+                yield return new TestCaseData(
+                    new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" },
+                    true,
+                    ScriptingImplementation.Mono2x
+                    ).SetName("FbxSdkIncludedAtRuntime_Mono").Returns(null);
+#if !UNITY_EDITOR_LINUX || UNITY_2019_3_OR_NEWER
+                yield return new TestCaseData(
+                    new string[] { k_runningBuildSymbol },
+                    false,
+                    ScriptingImplementation.IL2CPP
+                    ).SetName("FbxSdkNotIncludedAtRuntime_IL2CPP").Returns(null);
+                yield return new TestCaseData(
+                    new string[] { k_runningBuildSymbol, "FBXSDK_RUNTIME" },
+                    true,
+                    ScriptingImplementation.IL2CPP
+                    ).SetName("FbxSdkIncludedAtRuntime_IL2CPP").Returns(null);
+#endif // !UNITY_EDITOR_LINUX || UNITY_2019_3_OR_NEWER
             }
         }
 
@@ -69,13 +86,13 @@ namespace Autodesk.Fbx.BuildTests
         public void Term()
         {
             // reset the scripting define symbols
-            var symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+            var symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(k_buildTargetGroup);
             // remove the running build symbol and everything after it
             var result = symbols.Split(new string[] { k_runningBuildSymbol, ";" + k_runningBuildSymbol }, System.StringSplitOptions.None);
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, result[0]);
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(k_buildTargetGroup, result[0]);
 
             // set scripting backend back to default (Mono)
-            PlayerSettings.SetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup, ScriptingImplementation.Mono2x);
+            PlayerSettings.SetScriptingBackend(k_buildTargetGroup, ScriptingImplementation.Mono2x);
 
             // delete build folder
             if (Directory.Exists(BuildFolder))
@@ -89,7 +106,7 @@ namespace Autodesk.Fbx.BuildTests
             BuildPlayerOptions options = new BuildPlayerOptions();
             options.locationPathName = Path.Combine(BuildFolder, k_buildName);
             options.target = k_buildTarget;
-            options.targetGroup = BuildTargetGroup.Standalone;
+            options.targetGroup = k_buildTargetGroup;
             options.scenes = new string[] { k_buildTestScene };
 
             var report = BuildPipeline.BuildPlayer(options);
@@ -106,7 +123,7 @@ namespace Autodesk.Fbx.BuildTests
                 return;
             }
 
-            var symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
+            var symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(k_buildTargetGroup);
             if (!string.IsNullOrEmpty(symbols))
             {
                 symbols += ";";
@@ -117,18 +134,14 @@ namespace Autodesk.Fbx.BuildTests
             {
                 symbols += ";" + toAdd[i];
             }
-            PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, symbols);
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(k_buildTargetGroup, symbols);
         }
 
         [UnityTest]
         [TestCaseSource("RuntimeFbxSdkTestData")]
-        public IEnumerator TestFbxSdkAtRuntime(string[] defineSymbols, bool dllExists, bool useIL2CPP)
+        public IEnumerator TestFbxSdkAtRuntime(string[] defineSymbols, bool dllExists, ScriptingImplementation scriptingImplementation)
         {
-            if (useIL2CPP)
-            {
-                PlayerSettings.SetScriptingBackend(EditorUserBuildSettings.selectedBuildTargetGroup, ScriptingImplementation.IL2CPP);
-            }
-
+            PlayerSettings.SetScriptingBackend(k_buildTargetGroup, scriptingImplementation);
             AddDefineSymbols(defineSymbols);
 
             // start and stop playmode to force a domain reload
@@ -158,8 +171,9 @@ namespace Autodesk.Fbx.BuildTests
             }
             Assert.That(buildPluginFullPath, constraint);
 
-            // Autodesk.Fbx.dll will only exist if building with Mono
-            if(!useIL2CPP){
+            // Autodesk.Fbx.dll will not exist if building with IL2CPP
+            if(scriptingImplementation != ScriptingImplementation.IL2CPP)
+            {
                 // check the size of Autodesk.Fbx.dll
                 var autodeskDllFullPath = Path.Combine(
                         string.Format(k_buildPluginPath, buildPathWithoutExt),


### PR DESCRIPTION
Setting scripting backend to il2cpp will install il2cpp, but not change the project settings (unless platform is standalone).
Therefore, always use il2cpp (except ubuntu 2018.4 which does not have it), and modify the backend for the test that needs it to be il2cpp.