### PR TITLE
UT-3798 fix mac build failing when installing mono

### DIFF
--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -91,6 +91,9 @@ build_mac:
     flavor: {{ mac_platform.flavor}}
   commands:
     - HOMEBREW_NO_INSTALL_CLEANUP=1 brew list p7zip || brew install p7zip
+    # update httpie first, otherwise installing mono tries to update it and fails
+    # as it tries to delete the previous httpie which no longer exists.
+    - HOMEBREW_NO_INSTALL_CLEANUP=1 brew update && brew upgrade httpie
     - HOMEBREW_NO_INSTALL_CLEANUP=1 brew list mono || brew install mono
     - python ./build.py --stevedore --verbose --clean --yamato
     - mv build build-mac


### PR DESCRIPTION
temporary fix, ideally we would have our own bokken image with everything already installed: https://imgspc.atlassian.net/browse/UT-3796