### PR TITLE
FBX-27 add defines to use when generating documentation

### DIFF
--- a/proto.com.autodesk.fbx/Documentation~/config.json
+++ b/proto.com.autodesk.fbx/Documentation~/config.json
@@ -1,0 +1,1 @@
+{ "DefineConstants": "UNITY_EDITOR;FBXSDK_RUNTIME" }


### PR DESCRIPTION
- binding API documentation was not generated because of #if UNITY_EDITOR || FBXSDK_RUNTIME preprocessor directives.