### PR TITLE
Fix build.cmd to build.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,13 @@ Newer versions of each software likely also work.
 When installing Visual Studio, make sure to install C# sdk, C++ sdk, and Universal Windows App Development Tools (this can be done by doing a custom install or
 relaunching the installer and selecting "Modify").
 
-### OSX or Linux:
+### OSX, Linux, or Windows:
 
-```
+```bash
 # get the source
 git clone https://github.com/Unity-Technologies/com.autodesk.fbx.git
 cd com.autodesk.fbx
-./build.sh
-```
-
-### Windows:
-
-```
-# get the source
-git clone https://github.com/Unity-Technologies/com.autodesk.fbx.git
-cd com.autodesk.fbx
-build.cmd
+python build.py
 ```
 
 ## Overview


### PR DESCRIPTION
I have modified the commands listed in the README.

The files `build.sh` and `build.cmd` are mentioned in the README, but they don't exist, instead there is a file `build.py`.

I ran `python build.py` to see if it worked, and it did, so I fixed the README.