### PR TITLE
FBX-100: disable tests on linux

### DIFF
--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -62,11 +62,7 @@ promote_platform:
   image: package-ci/win10:stable
   flavor: b1.medium
 coverage:
-{% if platform.name == "ubuntu" %}
-  minPercent: 0
-{% else %}
   minPercent: 94.7
-{% endif %}
 ---
 
 build_win:
@@ -191,7 +187,10 @@ test_{{ platform.name }}_{{ editor.version }}:
     # Code coverage is only available in Unity 2019.3 and higher.
     # Setting backend to il2cpp to ensure il2cpp is installed and can be used by editor tests (see Note above).
     - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
+{% if platform.name != "ubuntu" %}
+    # Tests are temporarily disabled on linux (FBX-100)
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
+{% endif %}
 {% endif %}
     - echo "****** PASSED *******"
   triggers:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -62,7 +62,11 @@ promote_platform:
   image: package-ci/win10:stable
   flavor: b1.medium
 coverage:
+{% if platform.name == "ubuntu" %}
+  minPercent: 0
+{% else %}
   minPercent: 94.7
+{% endif %}
 ---
 
 build_win:

--- a/tests/RuntimeTests/Editor/BuildTests/FbxBuildTest.asmdef
+++ b/tests/RuntimeTests/Editor/BuildTests/FbxBuildTest.asmdef
@@ -9,6 +9,9 @@
     "optionalUnityReferences": [
         "TestAssemblies"
     ],
+    "defineConstraints": [
+        "!UNITY_EDITOR_LINUX"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false

--- a/tests/RuntimeTests/Editor/LinuxTests.meta
+++ b/tests/RuntimeTests/Editor/LinuxTests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b3d804af0f4545cfbf06ea1303f993a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/RuntimeTests/Editor/LinuxTests/LinuxTest.asmdef
+++ b/tests/RuntimeTests/Editor/LinuxTests/LinuxTest.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "FbxLinuxTest",
+    "references": [
+        "Autodesk.Fbx"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "defineConstraints": [
+        "UNITY_EDITOR_LINUX"
+    ],
+    "allowUnsafeCode": false
+}

--- a/tests/RuntimeTests/Editor/LinuxTests/LinuxTest.asmdef.meta
+++ b/tests/RuntimeTests/Editor/LinuxTests/LinuxTest.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 284a1dd56be7c47cb899b2e30abbcbf3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/RuntimeTests/Editor/LinuxTests/LinuxTest.cs
+++ b/tests/RuntimeTests/Editor/LinuxTests/LinuxTest.cs
@@ -1,0 +1,28 @@
+﻿// ***********************************************************************
+// Copyright (c) 2021 Unity Technologies. All rights reserved.  
+//
+// Licensed under the ##LICENSENAME##. 
+// See LICENSE.md file in the project root for full license information.
+// ***********************************************************************
+
+using NUnit.Framework;
+using Autodesk.Fbx;
+using System.IO;
+using System.Collections.Generic;
+
+namespace Autodesk.Fbx.LinuxTest
+{
+    /// <summary>
+    /// On linux, in v4.0.1, we temporarily have no tests because of an issue
+    /// with the CI machines not having libstdc++ required for FBX SDK.
+    ///
+    /// But we need at least one test. So here goes.
+    /// </summary>
+    internal class EmptyTest
+    {
+        [Test]
+        public static void Pass()
+        {
+        }
+    }
+}

--- a/tests/RuntimeTests/Editor/LinuxTests/LinuxTest.cs.meta
+++ b/tests/RuntimeTests/Editor/LinuxTests/LinuxTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 182e1a4b3ae7442339cad86b3af27d6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/RuntimeTests/Editor/PlayModeTests/PlayModeTests.asmdef
+++ b/tests/RuntimeTests/Editor/PlayModeTests/PlayModeTests.asmdef
@@ -9,7 +9,8 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "defineConstraints": [
-        "!FBX_RUNNING_BUILD_TEST"
+        "!FBX_RUNNING_BUILD_TEST",
+        "!UNITY_EDITOR_LINUX"
     ],
     "allowUnsafeCode": false
 }

--- a/tests/RuntimeTests/Editor/UnitTests/FbxUnitTests.asmdef
+++ b/tests/RuntimeTests/Editor/UnitTests/FbxUnitTests.asmdef
@@ -9,6 +9,9 @@
     "optionalUnityReferences": [
     "TestAssemblies"
     ],
+    "defineConstraints": [
+        "!UNITY_EDITOR_LINUX"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false

--- a/tests/RuntimeTests/Editor/UseCaseTests/FbxUseCaseTests.asmdef
+++ b/tests/RuntimeTests/Editor/UseCaseTests/FbxUseCaseTests.asmdef
@@ -9,6 +9,9 @@
     "optionalUnityReferences": [
         "TestAssemblies"
     ],
+    "defineConstraints": [
+        "!UNITY_EDITOR_LINUX"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false

--- a/tests/RuntimeTests/Runtime/BuildTestsAssets/FbxBuildTestAssets.asmdef
+++ b/tests/RuntimeTests/Runtime/BuildTestsAssets/FbxBuildTestAssets.asmdef
@@ -12,6 +12,9 @@
     "precompiledReferences": [
         "nunit.framework.dll"
     ],
+    "defineConstraints": [
+        "!UNITY_EDITOR_LINUX"
+    ],
     "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],


### PR DESCRIPTION
This is for the 4.0.1 release with Unity 2021.1 ; we should re-enable them for
2021.2 when we have time to deal with the libstdc++ issue.