### PR TITLE
FBX-46: Enable setting a string in a custom property

### DIFF
--- a/Source/fbxproperty.i
+++ b/Source/fbxproperty.i
@@ -172,14 +172,17 @@
 
 %template(Set) FbxProperty::Set<FbxColor>;
 %template(Set) FbxProperty::Set<float>;
+%template(Set) FbxProperty::Set<FbxString>;
 %template(EvaluateValue) FbxProperty::EvaluateValue<float>;
 
 /* Generic properties */
 %template("FbxPropertyBool") FbxPropertyT<FbxBool>;
 %template("FbxPropertyDouble") FbxPropertyT<FbxDouble>;
 %template("FbxPropertyDouble3") FbxPropertyT<FbxDouble3>;
-%template("FbxPropertyString") FbxPropertyT<FbxString>;
 %template("FbxPropertyInt") FbxPropertyT<signed int>;
+
+%csmethodmodifiers FbxPropertyT<FbxString>::Set(const FbxString&) "public new";
+%template("FbxPropertyString") FbxPropertyT<FbxString>;
 
 %csmethodmodifiers FbxPropertyT<float>::Set(const float&) "public new";
 %template("FbxPropertyFloat") FbxPropertyT<float>;

--- a/tests/RuntimeTests/Editor/UnitTests/FbxPropertyTest.cs
+++ b/tests/RuntimeTests/Editor/UnitTests/FbxPropertyTest.cs
@@ -133,6 +133,9 @@ namespace Autodesk.Fbx.UnitTests
             // Test setting the value with color accessor
             property.Set (new FbxColor ());
 
+            // Test setting the value with string accessor
+            property.Set ("MyCustomProperty");
+
             // test GetCurve(). Just make sure it doesn't crash. We can't
             // generically test actually getting curves, because the details
             // (channel names etc) depend on the type of property and its


### PR DESCRIPTION
The following function override now gets generated in FbxProperty.cs:
```
  public bool Set(float pValue) {
    bool ret = NativeMethods.FbxProperty_Set__SWIG_2(swigCPtr, pValue);
    if (NativeMethods.SWIGPendingException.Pending) throw NativeMethods.SWIGPendingException.Retrieve();
    return ret;
  }
```
Added automated test.
Built and tested on Unity 2021.1