### PR TITLE
FBX-163: set the min version of the build to 10.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ project (UnityFbxSdkNative)
 
 # CMake docs say this should be before project but it doesn't actually work that way.
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/deps")


### PR DESCRIPTION
This spews a lot of warnings because FBX SDK targets 10.15 but it still builds
a binary targeting 10.13 ; we'll need to test if it works. Otherwise, we need
to ask Autodesk to build an FBX SDK that targets 10.13.