### PR TITLE
Explicitly set codecoverage package version to 1.2.2 to fix code coverage failures for release 5.0 branch

### DIFF
--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -150,7 +150,7 @@ test_{{ platform.name }}_{{ editor.version }}:
     {% endif %}
     # Code coverage is only available in Unity 2019.3 and higher.
     # Setting backend to il2cpp to ensure il2cpp is installed and can be used by editor tests (see Note above).
-    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
+    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --extra-utr-arg=--coverage-pkg-version=1.2.2 --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
 {% if platform.name != "ubuntu" %}
     # Tests are temporarily disabled on linux (FBX-100)
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}


### PR DESCRIPTION
## Purpose of PR:
Explicitly set codecoverage package version to 1.2.2 to fix code coverage failures for release 5.0 branch