### PR TITLE
FBX-439 Fix editor versions in CI for release/4.2 branch

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -14,28 +14,31 @@ mac_platform: &mac
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu:stable
+  image: package-ci/ubuntu:prev-stable
   flavor: b1.medium
 
-win_platform:
+win_platform: &win
   name: win
   type: Unity::VM::GPU
   image: package-ci/win10:v4
   flavor: b1.medium
 
 platforms:
-  - *mac
-  - *ubuntu
-  - name: win
+  - name: mac
+    type: Unity::VM::osx
+    image: package-ci/macos-12:v4
+    flavor: m1.mac
+  - name: ubuntu
     type: Unity::VM
-    image: package-ci/win10:v1.15.0
+    image: package-ci/ubuntu-18.04:v4
     flavor: b1.medium
+  - *win
 
 promote_platform:
   version: 2020.3
   name: win
   type: Unity::VM
-  image: package-ci/win10:stable
+  image: package-ci/win10:v4
   flavor: b1.medium
 
 coverage:

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -1,18 +1,20 @@
 editors:
+  - version: 2018.4
+  - version: 2019.4
   - version: 2020.3
   - version: 2021.3
   - version: 2022.2
 
-mac_platform:
+mac_platform: &mac
   name: mac
   type: Unity::VM::osx
   image: package-ci/mac:stable
   flavor: m1.mac
 
-ubuntu_platform:
+ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu:prev-stable
+  image: package-ci/ubuntu:stable
   flavor: b1.medium
 
 win_platform:
@@ -22,25 +24,12 @@ win_platform:
   flavor: b1.medium
 
 platforms:
-  - name: mac
-    type: Unity::VM::osx
-    image: package-ci/mac:stable
-    flavor: m1.mac
-  - name: ubuntu
-    type: Unity::VM
-    image: package-ci/ubuntu:stable
-    flavor: b1.medium
+  - *mac
+  - *ubuntu
   - name: win
     type: Unity::VM
     image: package-ci/win10:v1.15.0
     flavor: b1.medium
-
-publish_platform:
-  version: 2020.3
-  name: win
-  type: Unity::VM
-  image: package-ci/win10:stable
-  flavor: b1.medium
 
 promote_platform:
   version: 2020.3

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -32,7 +32,10 @@ platforms:
     type: Unity::VM
     image: package-ci/ubuntu-18.04:v4
     flavor: b1.medium
-  - *win
+  - name: win
+    type: Unity::VM
+    image: package-ci/win10:v4
+    flavor: b1.medium
 
 promote_platform:
   version: 2020.3

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -76,7 +76,6 @@ build_ubuntu:
     - sudo apt-get update
     - sudo apt-get -y install gcc-9 g++-9
     - sudo apt-get install p7zip mono-devel
-    - sudo apt-get install libxml2-dev
     # Ensure correct version of gcc and g++ used
     # https://stackoverflow.com/questions/17275348/how-to-specify-new-gcc-path-for-cmake
     - CC=`which gcc-9` CXX=`which g++-9` python ./build.py --stevedore --verbose --clean --yamato

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -76,6 +76,7 @@ build_ubuntu:
     - sudo apt-get update
     - sudo apt-get -y install gcc-9 g++-9
     - sudo apt-get install p7zip mono-devel
+    - sudo apt-get install libxml2-dev
     # Ensure correct version of gcc and g++ used
     # https://stackoverflow.com/questions/17275348/how-to-specify-new-gcc-path-for-cmake
     - CC=`which gcc-9` CXX=`which g++-9` python ./build.py --stevedore --verbose --clean --yamato

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -213,9 +213,9 @@ promotion_test:
 publish:
   name: Publish to Internal Registry
   agent:
-    type: {{ publish_platform.type }}
-    image: {{ publish_platform.image }}
-    flavor: {{ publish_platform.flavor}}
+    type: Unity::VM
+    image: {{ win_platform.image }}
+    flavor: {{ win_platform.flavor}}
   variables:
     UPMCI_ENABLE_PACKAGE_SIGNING: 1
   commands:
@@ -234,7 +234,7 @@ publish:
 publish_dry_run:
   name: Publish to Internal Registry (Dry Run)
   agent:
-    type: {{ win_platform.type }}
+    type: Unity::VM
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor}}
   commands:
@@ -253,9 +253,9 @@ publish_dry_run:
 promote:
   name: Promote to Production
   agent:
-    type: {{ win_platform.type }}
-    image: {{ win_platform.image }}
-    flavor: b1.small
+    type: {{ promote_platform.type }}
+    image: {{ promote_platform.image }}
+    flavor: {{ promote_platform.flavor }}
   variables:
     UPMCI_PROMOTION: 1
   commands:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -231,6 +231,25 @@ publish:
     - .yamato/yamato.yml#pack
     - .yamato/yamato.yml#test_trigger_pr
 
+publish_dry_run:
+  name: Publish to Internal Registry (Dry Run)
+  agent:
+    type: {{ win_platform.type }}
+    image: {{ win_platform.image }}
+    flavor: {{ win_platform.flavor}}
+  commands:
+    - dir /A
+    - dir /A com.autodesk.fbx
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package publish --package-path com.autodesk.fbx --dry-run
+  artifacts:
+    packages:
+      paths:
+        - "upm-ci~/packages/**"
+  dependencies:
+    - .yamato/yamato.yml#pack
+    - .yamato/yamato.yml#test_trigger_pr
+
 promote:
   name: Promote to Production
   agent:


### PR DESCRIPTION
## Purpose of this PR:
In #372 , some master specific changes (the ones in .yamato folder) were merged into 4.2 branch unexpectedly, especially the ones about editor versions.
This PR does followings:
- Put back versions 2018.4 and 2019.4
- Use new package-ci images (v4 ones) for package test, old mac and ubuntu images are still needed for build jobs
- Add a `publish_dry_run` job so we can test publishing before real publishing
- Some other minor changes to CI

**JIRA ticket#**
[FBX-439](https://jira.unity3d.com/browse/FBX-439) Fix editor versions in CI for release/4.1 and release/4.2 branches