### PR TITLE
FBX-439 Fix editor versions in CI for release/4.1 branch

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -8,13 +8,13 @@ editors:
 mac_platform: &mac
   name: mac
   type: Unity::VM::osx
-  image: package-ci/mac:stable
+  image: package-ci/mac-12:v4
   flavor: m1.mac
 
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu:prev-stable
+  image: package-ci/ubuntu-18.04:v4
   flavor: b1.medium
 
 win_platform: &win
@@ -32,7 +32,7 @@ promote_platform:
   version: 2020.3
   name: win
   type: Unity::VM
-  image: package-ci/win10:stable
+  image: package-ci/win10:v4
   flavor: b1.medium
 
 coverage:

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -14,7 +14,7 @@ mac_platform: &mac
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu:stable
+  image: package-ci/ubuntu:prev-stable
   flavor: b1.medium
 
 win_platform: &win

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -8,13 +8,13 @@ editors:
 mac_platform: &mac
   name: mac
   type: Unity::VM::osx
-  image: package-ci/macos-12:v4
+  image: package-ci/mac:stable
   flavor: m1.mac
 
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu-18.04:v4
+  image: package-ci/ubuntu:prev-stable
   flavor: b1.medium
 
 win_platform: &win
@@ -25,7 +25,10 @@ win_platform: &win
 
 platforms:
   - *mac
-  - *ubuntu
+  - name: ubuntu
+    type: Unity::VM
+    image: package-ci/ubuntu:stable
+    flavor: b1.medium
   - *win
 
 promote_platform:

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -32,7 +32,10 @@ platforms:
     type: Unity::VM
     image: package-ci/ubuntu-18.04:v4
     flavor: b1.medium
-  - *win
+  - name: win
+    type: Unity::VM
+    image: package-ci/win10:v4
+    flavor: b1.medium
 
 promote_platform:
   version: 2020.3

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -8,7 +8,7 @@ editors:
 mac_platform: &mac
   name: mac
   type: Unity::VM::osx
-  image: package-ci/mac-12:v4
+  image: package-ci/macos-12:v4
   flavor: m1.mac
 
 ubuntu_platform: &ubuntu

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -1,46 +1,32 @@
 editors:
+  - version: 2018.4
+  - version: 2019.4
   - version: 2020.3
   - version: 2021.3
-  - version: 2022.2
+  - version: 2022.1
 
-mac_platform:
+mac_platform: &mac
   name: mac
   type: Unity::VM::osx
   image: package-ci/mac:stable
   flavor: m1.mac
 
-ubuntu_platform:
+ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu:prev-stable
+  image: package-ci/ubuntu:stable
   flavor: b1.medium
 
-win_platform:
+win_platform: &win
   name: win
   type: Unity::VM::GPU
   image: package-ci/win10:v4
   flavor: b1.medium
 
 platforms:
-  - name: mac
-    type: Unity::VM::osx
-    image: package-ci/mac:stable
-    flavor: m1.mac
-  - name: ubuntu
-    type: Unity::VM
-    image: package-ci/ubuntu:stable
-    flavor: b1.medium
-  - name: win
-    type: Unity::VM
-    image: package-ci/win10:v1.15.0
-    flavor: b1.medium
-
-publish_platform:
-  version: 2020.3
-  name: win
-  type: Unity::VM
-  image: package-ci/win10:stable
-  flavor: b1.medium
+  - *mac
+  - *ubuntu
+  - *win
 
 promote_platform:
   version: 2020.3

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -24,10 +24,13 @@ win_platform: &win
   flavor: b1.medium
 
 platforms:
-  - *mac
+  - name: mac
+    type: Unity::VM::osx
+    image: package-ci/macos-12:v4
+    flavor: m1.mac
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-18.04:v4
     flavor: b1.medium
   - *win
 

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -212,7 +212,7 @@ promotion_test:
 publish:
   name: Publish to Internal Registry
   agent:
-    type: {{ win_platform.type }}
+    type: Unity::VM
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor}}
   commands:
@@ -231,7 +231,7 @@ publish:
 publish_dry_run:
   name: Publish to Internal Registry (Dry Run)
   agent:
-    type: {{ win_platform.type }}
+    type: Unity::VM
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor}}
   commands:
@@ -250,9 +250,9 @@ publish_dry_run:
 promote:
   name: Promote to Production
   agent:
-    type: {{ win_platform.type }}
-    image: {{ win_platform.image }}
-    flavor: b1.small
+    type: {{ promote_platform.type }}
+    image: {{ promote_platform.image }}
+    flavor: {{ promote_platform.flavor}}
   variables:
     UPMCI_PROMOTION: 1
   commands:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -228,6 +228,25 @@ publish:
     - .yamato/yamato.yml#pack
     - .yamato/yamato.yml#test_trigger_pr
 
+publish_dry_run:
+  name: Publish to Internal Registry (Dry Run)
+  agent:
+    type: {{ win_platform.type }}
+    image: {{ win_platform.image }}
+    flavor: {{ win_platform.flavor}}
+  commands:
+    - dir /A
+    - dir /A com.autodesk.fbx
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package publish --package-path com.autodesk.fbx --dry-run
+  artifacts:
+    packages:
+      paths:
+        - "upm-ci~/packages/**"
+  dependencies:
+    - .yamato/yamato.yml#pack
+    - .yamato/yamato.yml#test_trigger_pr
+
 promote:
   name: Promote to Production
   agent:


### PR DESCRIPTION
## Purpose of this PR:
In #371, some master specific changes (the ones in .yamato folder) were merged into 4.1 branch unexpectedly, especially the ones about editor versions.

This PR does followings:
- Put back versions 2018.4 and 2019.4
- Use new package-ci images (v4 ones) for package test, old mac and ubuntu images are still needed for build jobs
- Add a publish_dry_run job so we can test publishing before real publishing
- Some other minor changes to CI
- 
JIRA ticket#
[FBX-439](https://jira.unity3d.com/browse/FBX-439) Fix editor versions in CI for release/4.1 and release/4.2 branches