### PR TITLE
FBX-447: Update bokken images and refactor CI

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -6,7 +6,7 @@ editors:
 mac_platform:
   name: mac
   type: Unity::VM::osx
-  image: package-ci/mac:stable
+  image: package-ci/macos-12:v4
   flavor: m1.mac
 
 ubuntu_platform:

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -3,44 +3,28 @@ editors:
   - version: 2021.3
   - version: 2022.2
 
-mac_platform:
+mac_platform: &mac
   name: mac
   type: Unity::VM::osx
   image: package-ci/macos-12:v4
   flavor: m1.mac
 
-ubuntu_platform:
+ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
   image: package-ci/ubuntu-18.04:v4
   flavor: b1.medium
 
-win_platform:
-  name: win
-  type: Unity::VM::GPU
-  image: package-ci/win10:v4
-  flavor: b1.medium
-
-platforms:
-  - name: mac
-    type: Unity::VM::osx
-    image: package-ci/mac:stable
-    flavor: m1.mac
-  - name: ubuntu
-    type: Unity::VM
-    image: package-ci/ubuntu:stable
-    flavor: b1.medium
-  - name: win
-    type: Unity::VM
-    image: package-ci/win10:v4
-    flavor: b1.medium
-
-publish_platform:
-  version: 2020.3
+win_platform: &win
   name: win
   type: Unity::VM
   image: package-ci/win10:v4
   flavor: b1.medium
+
+platforms:
+  - *mac
+  - *ubuntu
+  - *win
 
 promote_platform:
   version: 2020.3

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -12,7 +12,7 @@ mac_platform:
 ubuntu_platform:
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu:prev-stable
+  image: package-ci/ubuntu-18.04:v4
   flavor: b1.medium
 
 win_platform:
@@ -32,21 +32,21 @@ platforms:
     flavor: b1.medium
   - name: win
     type: Unity::VM
-    image: package-ci/win10:v1.15.0
+    image: package-ci/win10:v4
     flavor: b1.medium
 
 publish_platform:
   version: 2020.3
   name: win
   type: Unity::VM
-  image: package-ci/win10:stable
+  image: package-ci/win10:v4
   flavor: b1.medium
 
 promote_platform:
   version: 2020.3
   name: win
   type: Unity::VM
-  image: package-ci/win10:stable
+  image: package-ci/win10:v4
   flavor: b1.medium
 
 coverage:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -56,6 +56,7 @@ build_mac:
     # elevates privileges. So we need to set it via pip config.
     - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - brew list p7zip || brew install p7zip
+    - export MONO_GAC_PREFIX="$(brew --prefix)"
     - brew list mono || brew install mono
     - python ./build.py --stevedore --verbose --clean --yamato
     - mv build build-mac

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -29,7 +29,7 @@
 build_win:
   name: Build on win
   agent:
-    type: {{ win_platform.type }}
+    type: Unity::VM::GPU
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor}}
   commands:
@@ -226,9 +226,9 @@ promotion_test:
 publish:
   name: Publish to Internal Registry
   agent:
-    type: {{ publish_platform.type }}
-    image: {{ publish_platform.image }}
-    flavor: {{ publish_platform.flavor}}
+    type: {{ win_platform.type }}
+    image: {{ win_platform.image }}
+    flavor: {{ win_platform.flavor }}
   variables:
     UPMCI_ENABLE_PACKAGE_SIGNING: 1
   commands:
@@ -244,12 +244,33 @@ publish:
     - .yamato/yamato.yml#pack
     - .yamato/yamato.yml#test_trigger_pr
 
-promote:
-  name: Promote to Production
+publish_dry_run:
+  name: Publish to Internal Registry (Dry Run)
   agent:
     type: {{ win_platform.type }}
     image: {{ win_platform.image }}
-    flavor: b1.small
+    flavor: {{ win_platform.flavor }}
+  variables:
+    UPMCI_ENABLE_PACKAGE_SIGNING: 1
+  commands:
+    - dir /A 
+    - dir /A com.autodesk.fbx
+    - npm install upm-ci-utils@latest -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package publish --package-path com.autodesk.fbx --dry-run
+  artifacts:
+    packages:
+      paths:
+        - "upm-ci~/packages/**"
+  dependencies:
+    - .yamato/yamato.yml#pack
+    - .yamato/yamato.yml#test_trigger_pr
+
+promote:
+  name: Promote to Production
+  agent:
+    type: {{ promote_platform.type }}
+    image: {{ promote_platform.image }}
+    flavor: {{ promote_platform.flavor }}
   variables:
     UPMCI_PROMOTION: 1
   commands:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -56,8 +56,6 @@ build_mac:
     # elevates privileges. So we need to set it via pip config.
     - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - brew list p7zip || brew install p7zip
-    - export MONO_GAC_PREFIX="$(brew --prefix)"
-    - brew list mono || brew install mono
     - python ./build.py --stevedore --verbose --clean --yamato
     - mv build build-mac
   artifacts:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -75,6 +75,7 @@ build_ubuntu:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get update
     - sudo apt-get -y install cmake
+    - sudo apt-get install libxml2-dev
     - sudo apt-get -y install gcc-9 g++-9
     - sudo apt-get install p7zip mono-devel
     # Ensure correct version of gcc and g++ used

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -74,6 +74,7 @@ build_ubuntu:
     # FBX SDK 2020.2 requires gcc 9.3
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get update
+    - sudo apt-get -y install cmake
     - sudo apt-get -y install gcc-9 g++-9
     - sudo apt-get install p7zip mono-devel
     # Ensure correct version of gcc and g++ used

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -56,6 +56,7 @@ build_mac:
     # elevates privileges. So we need to set it via pip config.
     - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - brew list p7zip || brew install p7zip
+    - cmake --version || brew install cmake
     - python ./build.py --stevedore --verbose --clean --yamato
     - mv build build-mac
   artifacts:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -75,7 +75,7 @@ build_ubuntu:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get update
     - sudo apt-get -y install cmake
-    - sudo apt-get install libxml2-dev
+    - sudo apt-get -y install libxml2-dev
     - sudo apt-get -y install gcc-9 g++-9
     - sudo apt-get install p7zip mono-devel
     # Ensure correct version of gcc and g++ used


### PR DESCRIPTION
## Purpose of this PR:
Update bokken images to new ones in CI

**JIRA tickets:**
[FBX-447](https://jira.unity3d.com/browse/FBX-447)
Investigate build failures on new package-ci images: macos-12:v4 and ubuntu18.04:v4 for com.autodesk.fbx package
[FBX-453](https://jira.unity3d.com/browse/FBX-453)
CI: Investigate "Build on mac" job failure

**Changes of this PR:**
- Update bokken images to new ones (v4 ones)
- Install cmake on `macos-12:v4` and `ubuntu-18.04:v4` 
- Remove mono install command on mac because mono is preinstalled on `macos-12:v4`
- Install `libxml2-dev` on `ubuntu-18.04:v4` 
- Do some cleanup and refactoring to global.metafile
- Add a publish dry-run job