### PR TITLE
FBX-447: Update bokken images and refactor CI (Backport #385 to release/4.1)

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -8,34 +8,25 @@ editors:
 mac_platform: &mac
   name: mac
   type: Unity::VM::osx
-  image: package-ci/mac:stable
+  image: package-ci/macos-12:v4
   flavor: m1.mac
 
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu:prev-stable
+  image: package-ci/ubuntu-18.04:v4
   flavor: b1.medium
 
 win_platform: &win
   name: win
-  type: Unity::VM::GPU
+  type: Unity::VM
   image: package-ci/win10:v4
   flavor: b1.medium
 
 platforms:
-  - name: mac
-    type: Unity::VM::osx
-    image: package-ci/macos-12:v4
-    flavor: m1.mac
-  - name: ubuntu
-    type: Unity::VM
-    image: package-ci/ubuntu-18.04:v4
-    flavor: b1.medium
-  - name: win
-    type: Unity::VM
-    image: package-ci/win10:v4
-    flavor: b1.medium
+  - *mac
+  - *ubuntu
+  - *win
 
 promote_platform:
   version: 2020.3

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -29,7 +29,7 @@
 build_win:
   name: Build on win
   agent:
-    type: {{ win_platform.type }}
+    type: Unity::VM::GPU
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor}}
   commands:
@@ -56,7 +56,7 @@ build_mac:
     # elevates privileges. So we need to set it via pip config.
     - pip config set global.index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
     - brew list p7zip || brew install p7zip
-    - brew list mono || brew install mono
+    - cmake --version || brew install cmake
     - python ./build.py --stevedore --verbose --clean --yamato
     - mv build build-mac
   artifacts:
@@ -74,6 +74,8 @@ build_ubuntu:
     # FBX SDK 2020.2 requires gcc 9.3
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get update
+    - sudo apt-get -y install cmake
+    - sudo apt-get -y install libxml2-dev
     - sudo apt-get -y install gcc-9 g++-9
     - sudo apt-get install p7zip mono-devel
     # Ensure correct version of gcc and g++ used
@@ -223,7 +225,7 @@ promotion_test:
 publish:
   name: Publish to Internal Registry
   agent:
-    type: Unity::VM
+    type: {{ win_platform.type }}
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor}}
   commands:
@@ -242,7 +244,7 @@ publish:
 publish_dry_run:
   name: Publish to Internal Registry (Dry Run)
   agent:
-    type: Unity::VM
+    type: {{ win_platform.type }}
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor}}
   commands:


### PR DESCRIPTION
## Purpose of this PR:
Backport https://github.com/Unity-Technologies/com.autodesk.fbx/pull/385 to release/4.1 branch.

**JIRA tickets:**
[FBX-447](https://jira.unity3d.com/browse/FBX-447)
Investigate build failures on new package-ci images: macos-12:v4 and ubuntu18.04:v4 for com.autodesk.fbx package
[FBX-453](https://jira.unity3d.com/browse/FBX-453)
CI: Investigate "Build on mac" job failure