### PR TITLE
Nojira: Remove GPU for build_win job

### DIFF
--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -29,7 +29,7 @@
 build_win:
   name: Build on win
   agent:
-    type: Unity::VM::GPU
+    type: {{ win_platform.type }}
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor}}
   commands:


### PR DESCRIPTION
## Purpose of this PR:
Previously `build_win` job needs a Win VM with GPU to run. GPU resources are limited and the distribution time for GPU is very long.
Tried with `win10:v4` image today and found GPU is not needed any more for build_win job which will save a lot of time for CI pipeline.