### PR TITLE
Nojira: Remove GPU from build_win job (release/4.1)

### DIFF
--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -29,7 +29,7 @@
 build_win:
   name: Build on win
   agent:
-    type: Unity::VM::GPU
+    type: {{ win_platform.type }}
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor}}
   commands:


### PR DESCRIPTION
## Purpose of this PR:
Remove GPU from build_win job, it is not needed now.