### PR TITLE
Nojira: Add 'set -e' so that build script on Linux will not fail silently

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,3 +1,8 @@
+#!/bin/bash
+
+## Any subsequent(*) commands which fail will cause the shell script to exit immediately, otherwise the job will fail silently.
+set -e
+
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update
 sudo apt-get -y install cmake


### PR DESCRIPTION
## Purpose of this PR:
Add 'set -e' so that build script on Linux will not fail silently. A little improvement to CI.