### PR TITLE
Re-enable Ubuntu tests (FBX-468)

### DIFF
--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -133,10 +133,7 @@ test_{{ platform.name }}_{{ editor.version }}:
     # Code coverage is only available in Unity 2019.3 and higher.
     # Setting backend to il2cpp to ensure il2cpp is installed and can be used by editor tests (see Note above).
     - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --extra-utr-arg=--coverage-pkg-version=1.2.2 --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
-{% if platform.name != "ubuntu" %}
-    # Tests are temporarily disabled on linux (FBX-100)
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
-{% endif %}
 {% endif %}
     - echo "****** PASSED *******"
   artifacts:

--- a/tests/RuntimeTests/Editor/BuildTests/Autodesk.Fbx.BuildTest.asmdef
+++ b/tests/RuntimeTests/Editor/BuildTests/Autodesk.Fbx.BuildTest.asmdef
@@ -9,9 +9,6 @@
     "optionalUnityReferences": [
         "TestAssemblies"
     ],
-    "defineConstraints": [
-        "!UNITY_EDITOR_LINUX"
-    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false

--- a/tests/RuntimeTests/Editor/PlayModeTests/Autodesk.Fbx.PlayModeTests.asmdef
+++ b/tests/RuntimeTests/Editor/PlayModeTests/Autodesk.Fbx.PlayModeTests.asmdef
@@ -9,8 +9,7 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "defineConstraints": [
-        "!FBX_RUNNING_BUILD_TEST",
-        "!UNITY_EDITOR_LINUX"
+        "!FBX_RUNNING_BUILD_TEST"
     ],
     "allowUnsafeCode": false
 }

--- a/tests/RuntimeTests/Editor/UnitTests/Autodesk.Fbx.UnitTests.asmdef
+++ b/tests/RuntimeTests/Editor/UnitTests/Autodesk.Fbx.UnitTests.asmdef
@@ -9,9 +9,6 @@
     "optionalUnityReferences": [
     "TestAssemblies"
     ],
-    "defineConstraints": [
-        "!UNITY_EDITOR_LINUX"
-    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false

--- a/tests/RuntimeTests/Editor/UseCaseTests/Autodesk.Fbx.UseCaseTests.asmdef
+++ b/tests/RuntimeTests/Editor/UseCaseTests/Autodesk.Fbx.UseCaseTests.asmdef
@@ -9,9 +9,6 @@
     "optionalUnityReferences": [
         "TestAssemblies"
     ],
-    "defineConstraints": [
-        "!UNITY_EDITOR_LINUX"
-    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false

--- a/tests/RuntimeTests/Runtime/BuildTestsAssets/Autodesk.Fbx.BuildTestAssets.asmdef
+++ b/tests/RuntimeTests/Runtime/BuildTestsAssets/Autodesk.Fbx.BuildTestAssets.asmdef
@@ -12,9 +12,6 @@
     "precompiledReferences": [
         "nunit.framework.dll"
     ],
-    "defineConstraints": [
-        "!UNITY_EDITOR_LINUX"
-    ],
     "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],


### PR DESCRIPTION
The goal is to make the tests run again on our CI again.
Issues remain on Ubuntu18 (so with APV/QV), but can be workaround using the package exemption mechanism.

- Re-enabling Linux tests
- See corresponding [PR](https://github.com/Unity-Technologies/com.unity.formats.fbx/pull/699) for the exporter
