### PR TITLE
FBX-465 CI: Fix com.autodesk build failure on Ubuntu 20

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -14,7 +14,7 @@ mac_platform: &mac
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu-20.04:v4
+  image: package-ci/ubuntu-18.04:v4
   flavor: b1.medium
 
 win_platform: &win

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -14,7 +14,7 @@ mac_platform: &mac
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu-18.04:v4
+  image: package-ci/ubuntu-20.04:v4
   flavor: b1.medium
 
 win_platform: &win

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -5,6 +5,7 @@ set -e
 
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update
+sudo apt-get -y install zlib1g-dev
 sudo apt-get -y install cmake
 sudo apt-get -y install libxml2-dev
 sudo apt-get -y install gcc-9 g++-9


### PR DESCRIPTION
## Purpose of this PR:
Fix com.autodesk build failure on Ubuntu 20

**JIRA ticket:**
[FBX-465](https://jira.unity3d.com/browse/FBX-465) CI: Fix com.autodesk build failure on Ubuntu 20