### PR TITLE
FBX-479 CI: Fix build job failures on Mac and Ubuntu

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -8,7 +8,7 @@ editors:
 mac_platform: &mac
   name: mac
   type: Unity::VM::osx
-  image: package-ci/macos-12:v4
+  image: package-ci/macos-12:v4.19.0
   flavor: m1.mac
 
 ubuntu_platform: &ubuntu

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -9,7 +9,7 @@ sudo apt-get -y install zlib1g-dev
 sudo apt-get -y install cmake
 sudo apt-get -y install libxml2-dev
 sudo apt-get -y install gcc-9 g++-9
-sudo apt-get install p7zip mono-devel
+sudo apt-get -y install p7zip mono-devel
 # Ensure correct version of gcc and g++ used
 # https://stackoverflow.com/questions/17275348/how-to-specify-new-gcc-path-for-cmake
 CC=`which gcc-9` CXX=`which g++-9` python ./build.py --stevedore --verbose --clean --yamato


### PR DESCRIPTION
## Purpose of this PR:
[Build on Ubuntu](https://unity-ci.cds.internal.unity3d.com/project/178/branch/master/jobDefinition/.yamato%2Fpack-autodesk-fbx.yml%23build_ubuntu) also began to fail on 6th July and [Build on Mac](https://unity-ci.cds.internal.unity3d.com/project/178/branch/master/jobDefinition/.yamato%2Fpack-autodesk-fbx.yml%23build_mac) job began to fail on around 1st July.

Without this PR, I see a following build error on Mac:
```
/Users/bokken/build/output/Unity-Technologies/com.autodesk.fbx/build/deps/fbxsdk-mac-x64/include/fbxsdk/core/arch/fbxstdcompliant.h:52:96: error: 'vsprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead. [-Werror,-Wdeprecated-declarations]
```
This happens with `macos-12:v4.20.0`, but **not with** `macos-12:v4.19.0`. So I believe the new macos-12 image version begins to throw errors when meeting the deprecated API `vsprintf`.

**JIRA#**
[FBX-479](https://jira.unity3d.com/browse/FBX-479) CI: Fix build job failures on Mac and Ubuntu