### PR TITLE
FBX-479 CI: Fix build errors on Ubuntu and Mac for release/4.1 branch

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -8,7 +8,8 @@ editors:
 mac_platform: &mac
   name: mac
   type: Unity::VM::osx
-  image: package-ci/macos-12:v4
+  # Pin Mac image to v4.19.0 because of https://jira.unity3d.com/browse/FBX-479
+  image: package-ci/macos-12:v4.19.0
   flavor: m1.mac
 
 ubuntu_platform: &ubuntu

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -77,7 +77,7 @@ build_ubuntu:
     - sudo apt-get -y install cmake
     - sudo apt-get -y install libxml2-dev
     - sudo apt-get -y install gcc-9 g++-9
-    - sudo apt-get install p7zip mono-devel
+    - sudo apt-get -y install p7zip mono-devel
     # Ensure correct version of gcc and g++ used
     # https://stackoverflow.com/questions/17275348/how-to-specify-new-gcc-path-for-cmake
     - CC=`which gcc-9` CXX=`which g++-9` python ./build.py --stevedore --verbose --clean --yamato


### PR DESCRIPTION
## Purpose of this PR:
Fix build job failures on Ubuntu and Mac for release/4.1 branch. This is a backport PR.

JIRA ticket:
[FBX-479](https://jira.unity3d.com/browse/FBX-479) CI: Fix build job failures on Mac and Ubuntu