### PR TITLE
CI: FBX-132 Run automated tests on Apple Silicon machine and add missing Editors

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -1,8 +1,9 @@
 editors:
   - version: 2020.3
   - version: 2021.3
-  - version: 2022.2
+  - version: 2022.3
   - version: 2023.1
+  - version: 2023.2
   - version: trunk
 
 mac_platform: &mac

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -12,6 +12,13 @@ mac_platform: &mac
   image: package-ci/macos-12:v4.19.0
   flavor: m1.mac
 
+mac_arm64_platform: &mac_arm64
+  name: mac_arm64
+  type: Unity::VM::osx
+  model: M1
+  image: slough-ops/macos-13-arm64-base
+  flavor: m1.mac
+
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
@@ -26,6 +33,7 @@ win_platform: &win
 
 platforms:
   - *mac
+  - *mac_arm64
   - *ubuntu
   - *win
 

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -16,7 +16,7 @@ mac_arm64_platform: &mac_arm64
   name: mac_arm64
   type: Unity::VM::osx
   model: M1
-  image: slough-ops/macos-13-arm64-base:latest
+  image: package-ci/macos-13-arm64:v4
   flavor: m1.mac
 
 ubuntu_platform: &ubuntu

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -16,7 +16,7 @@ mac_arm64_platform: &mac_arm64
   name: mac_arm64
   type: Unity::VM::osx
   model: M1
-  image: slough-ops/macos-13-arm64-base
+  image: slough-ops/macos-13-arm64-base:latest
   flavor: m1.mac
 
 ubuntu_platform: &ubuntu

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -185,11 +185,6 @@ promotion_test:
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package test --backend il2cpp --unity-version {{ promote_platform.version }} --package-path com.autodesk.fbx
-  triggers:
-    pull_requests:
-      - targets:
-          only:
-            - "master"
   artifacts:
     logs:
       paths:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -102,6 +102,9 @@ test_{{ platform.name }}_{{ editor.version }}:
   name : Test version {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
+{% if platform.model %}
+    model: platform.model
+{% endif %}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
 {% if platform.name == "ubuntu" %}
@@ -115,26 +118,13 @@ test_{{ platform.name }}_{{ editor.version }}:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get update
     - sudo apt-get -y install --only-upgrade libstdc++6  
-{% endif %} 
-{% if editor.version == 2018.4 and platform.name == "ubuntu" %}
-    # There is no IL2CPP on Ubuntu before 2019.3
-    - upm-ci package test --backend mono --unity-version {{ editor.version }} --package-path com.autodesk.fbx
-{% elseif editor.version == 2018.4 %}
-    # Setting backend to il2cpp to ensure il2cpp is installed.
-    # Note: setting backend to il2cpp will still run the tests with mono by default 
-    #       (would need to add --platform standalone to run playmode tests with il2cpp),
-    #       however this installs il2cpp so that the editor build tests can change the backend as necessary.
-    - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx
-{% else %}
-    {% if platform.name == "ubuntu" %}
     # clang required for il2cpp backend
     - sudo apt-get -y install clang
-    {% endif %}
+{% endif %}
     # Code coverage is only available in Unity 2019.3 and higher.
     # Setting backend to il2cpp to ensure il2cpp is installed and can be used by editor tests (see Note above).
     - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --extra-utr-arg=--coverage-pkg-version=1.2.2 --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
-{% endif %}
     - echo "****** PASSED *******"
   artifacts:
     packages:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -103,7 +103,7 @@ test_{{ platform.name }}_{{ editor.version }}:
   agent:
     type: {{ platform.type }}
 {% if platform.model %}
-    model: platform.model
+    model: {{ platform.model }}
 {% endif %}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}


### PR DESCRIPTION
## Purpose of this PR:
Run FBX SDK tests on Silicon Mac VM and add missing editors to CI.

**List of changes:**
- Add a `mac_arm64_platform` to CI which will run macOS 13 on Apple Silicon VM
- Add Editors `2022.3` and `2023.2` to CI for better coverage
- Clean up some outdated codes in CI which still refer to `2018.4`
- Remove promotion test from PR trigger. First promotion test shouldn't be in PR trigger, second it fails most of the time complaining the current package version already exists in package registry.

**JIRA ticket:**
[FBX-132](https://jira.unity3d.com/browse/FBX-132) Run automated tests on Apple Silicon machine