### PR TITLE
Wind/add doc validation jobs

### DIFF
--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -96,6 +96,48 @@ pack:
       paths:
         - "com.autodesk.fbx/**"
 
+# Job to check whether APIs are doced properly.
+validate_api_doc:
+  name: Validate API documentation
+  agent:
+    type: {{ ubuntu_platform.type }}
+    image: {{ ubuntu_platform.image }}
+    flavor: {{ ubuntu_platform.flavor }}
+  commands:
+    # Needed for now, until we get a recent upm-pvp into the image.
+    - sudo apt-get update && sudo apt-get install -y upm-pvp
+    # Download Unity.
+    - unity-downloader-cli --fast --wait -u {{ editors.last.version }} -c editor
+    # Run PVS in PVP mode.
+    - upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results "upm-ci~/pvp"
+    # Require that PVP-20-1 (API docs validation) passed.
+    - upm-pvp require PVP-20-1 --results "upm-ci~/pvp" --failures "upm-ci~/pvp/failures.json"
+  artifacts:
+    pvp:
+      paths:
+        - upm-ci~/pvp/**
+    logs:
+      paths:
+        - upm-ci~/test-results/**
+  dependencies:
+    - .yamato/yamato.yml#pack
+
+# Job to generate documentation for the package
+generate_documentation:
+  name : Generate documentation
+  agent:
+    type: {{ mac_platform.type }}
+    image: {{ mac_platform.image }}
+    flavor: {{ mac_platform.flavor }}
+  commands:
+    - brick_source: git@github.cds.internal.unity3d.com:wind-xu/virtual_production_doc_generation.git@v0.2.0
+      variables:
+        EDITOR_VERSION: {{ editors.last.version }}
+        PACKAGE_NAME: com.autodesk.fbx
+        PACKAGE_PATH: com.autodesk.fbx
+        #Treat doc build warnings as errors
+        WARNINGS_AS_ERRORS: false
+
 {% for editor in editors %}
 {% for platform in platforms %}
 test_{{ platform.name }}_{{ editor.version }}:

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -182,12 +182,21 @@ test_{{ platform.name }}_{{ editor.version }}:
 {% endfor %}
 {% endfor %}
 
+# PR trigger for doc only changes, it will run generate_documentation job.
+test_trigger_pr_documentation:
+  name: Pull Request Tests Trigger for documentation changes
+  triggers:
+    cancel_old_ci: true
+    expression: pull_request.(source match ".*" AND push.changes.all match "**/*.md" AND NOT draft)
+  dependencies:
+    - .yamato/yamato.yml#generate_documentation
+
 # PR trigger
 test_trigger_pr:
   name: Pull Request Tests Trigger
   triggers:
     cancel_old_ci: true
-    expression: pull_request.(source match ".*" AND NOT draft)
+    expression: pull_request.(source match ".*" AND NOT push.changes.all match "**/*.md" AND NOT draft)
   dependencies:
     - .yamato/yamato.yml#pack
 {% for editor in editors %}

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -130,7 +130,7 @@ generate_documentation:
     image: {{ mac_platform.image }}
     flavor: {{ mac_platform.flavor }}
   commands:
-    - brick_source: git@github.cds.internal.unity3d.com:wind-xu/virtual_production_doc_generation.git@v0.2.0
+    - brick_source: git@github.cds.internal.unity3d.com:wind-xu/virtual_production_doc_generation.git@v0.3.0
       variables:
         EDITOR_VERSION: {{ editors.last.version }}
         PACKAGE_NAME: com.autodesk.fbx

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -137,6 +137,8 @@ generate_documentation:
         PACKAGE_PATH: com.autodesk.fbx
         #Treat doc build warnings as errors
         WARNINGS_AS_ERRORS: false
+  dependencies:
+    - .yamato/yamato.yml#pack
 
 {% for editor in editors %}
 {% for platform in platforms %}


### PR DESCRIPTION
## Purpose of this PR:
Add doc generation job to FBX SDK package and add a PR trigger for doc only changes.

**JIRA ticket:**
[FBX-496](https://jira.unity3d.com/browse/FBX-496) CI: Add documentation generation job for FBX CI and a corresponding doc change trigger.