### PR TITLE
CI: Add package test jobs on ARM64 Windows for FBX SDK

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -33,6 +33,7 @@ win_platform: &win
 win_arm64_platform: &win_arm64
   name: win_arm64
   type: Unity::VM::Azure
+  model: arm
   image: package-ci/win11-arm64:v4
   flavor: b1.large
 

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -2,7 +2,6 @@ editors:
   - version: 2020.3
   - version: 2021.3
   - version: 2022.3
-  - version: 2023.1
   - version: 2023.2
   - version: trunk
 
@@ -23,19 +22,26 @@ ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
   image: package-ci/ubuntu-20.04:v4
-  flavor: b1.medium
+  flavor: b1.large
 
 win_platform: &win
   name: win
   type: Unity::VM
   image: package-ci/win10:v4
-  flavor: b1.medium
+  flavor: b1.large
+
+win_arm64_platform: &win_arm64
+  name: win_arm64
+  type: Unity::VM::Azure
+  image: package-ci/win11-arm64:v4
+  flavor: b1.large
 
 platforms:
   - *mac
   - *mac_arm64
   - *ubuntu
   - *win
+  - *win_arm64
 
 promote_platform:
   version: 2020.3

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -135,9 +135,14 @@ test_{{ platform.name }}_{{ editor.version }}:
     # clang required for il2cpp backend
     - sudo apt-get -y install clang
 {% endif %}
-    # Code coverage is only available in Unity 2019.3 and higher.
+# So when the platform is Silicon Mac or ARM64 Windows, we need to explicitly download ARM64 vesion editor.
+{% if platform.model == "M1" or platform.model == "arm" %}
+    - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
     # Setting backend to il2cpp to ensure il2cpp is installed and can be used by editor tests (see Note above).
+    - upm-ci package test --backend il2cpp --unity-version .Editor --package-path com.autodesk.fbx --enable-code-coverage --extra-utr-arg=--coverage-pkg-version=1.2.2 --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
+{% else %}
     - upm-ci package test --backend il2cpp --unity-version {{ editor.version }} --package-path com.autodesk.fbx --enable-code-coverage --extra-utr-arg=--coverage-pkg-version=1.2.2 --code-coverage-options 'generateHtmlReport;assemblyFilters:+Autodesk.Fbx'
+{% endif %}
     - python tests/Yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
     - echo "****** PASSED *******"
   artifacts:
@@ -171,7 +176,10 @@ test_trigger_pr:
     - .yamato/yamato.yml#pack
 {% for editor in editors %}
 {% for platform in platforms %}
+# Only run tests in trunk if on Silicon Mac or ARM64 Windows. On other platforms, run tests in all Editor versions.
+{% if editor.version == "trunk" or platform.model != "M1" and platform.model != "arm" %}
     - .yamato/yamato.yml#test_{{ platform.name }}_{{ editor.version }}
+{% endif %}
 {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
## Purpose of this PR:
- Add test jobs on ARM64 Win.
- Also removed 2023.1 from CI and change image flavor from `b1.medium` to `b1.large` which is the recommended one.

JIRA ticket:
[FBX-519](https://jira.unity3d.com/browse/FBX-519) CI: Add package test jobs for ARM64 Windows