### PR TITLE
Add build jobs on Arm64 Win

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -2,7 +2,6 @@ editors:
   - version: 2020.3
   - version: 2021.3
   - version: 2022.3
-  - version: 2023.2
   - version: trunk
 
 mac_platform: &mac

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -99,11 +99,6 @@ pack:
     - .yamato/yamato.yml#build_mac
     - .yamato/yamato.yml#build_ubuntu
   artifacts:
-    build:
-      paths:
-        - "build-ubuntu/install/**"
-        - "build-mac/install/**"
-        - "build-win/install/**"
     packages:
       paths:
         - "upm-ci~/packages/**"

--- a/.yamato/yamato.yml
+++ b/.yamato/yamato.yml
@@ -39,6 +39,20 @@ build_win:
       paths:
         - "build-win/install/**"
 
+build_win_arm64:
+  name: Build on win arm64
+  agent:
+    type: {{ win_arm64_platform.type }}
+    model: {{ win_arm64_platform.model }}
+    image: {{ win_arm64_platform.image }}
+    flavor: {{ win_arm64_platform.flavor}}
+  commands:
+    - build_win.cmd
+  artifacts:
+    build:
+      paths:
+        - "build-win/install/**"
+
 build_mac:
   name: Build on mac
   agent:
@@ -81,6 +95,7 @@ pack:
     - upm-ci package pack --package-path com.autodesk.fbx
   dependencies:
     - .yamato/yamato.yml#build_win
+    - .yamato/yamato.yml#build_win_arm64
     - .yamato/yamato.yml#build_mac
     - .yamato/yamato.yml#build_ubuntu
   artifacts:

--- a/build.py
+++ b/build.py
@@ -12,7 +12,7 @@ osx_deployment_target = "10.15"
 parser = argparse.ArgumentParser(description='Parse the options')
 parser.add_argument('--swig', type=str, dest='swig_location', help='Root location of the swig executable')
 parser.add_argument('--fbxsdk', type=str, dest='fbxsdk_location', help='location of the FBX SDK')
-parser.add_argument('--architecture', type=str, default='x64', dest='target_architecture', help='Target architecture of the build')
+parser.add_argument('--target', type=str, default='amd64', dest='target_architecture', help='Target architecture of the build')
 parser.add_argument('-s', '--stevedore', action='store_true', dest='use_stevedore', help='Use stevedore (used for internal builds)')
 parser.add_argument('-n', '--ninja', action='store_true', dest='use_ninja', help='Generate Ninja build files')
 parser.add_argument('-t', '--build_type', default='Release', dest='build_type', help='Build type to do (Release, Debug, ...)')

--- a/build.py
+++ b/build.py
@@ -8,12 +8,11 @@ import platform
 
 # Defaults
 osx_deployment_target = "10.15"
-# To build for arm64, Visual Studio 2022 is needed.
-vs_generator_name = "Visual Studio 16 2019" if platform.machine() in ['x86_64', 'AMD64'] else "Visual Studio 17 2022"
 
 parser = argparse.ArgumentParser(description='Parse the options')
 parser.add_argument('--swig', type=str, dest='swig_location', help='Root location of the swig executable')
 parser.add_argument('--fbxsdk', type=str, dest='fbxsdk_location', help='location of the FBX SDK')
+parser.add_argument('--architecture', type=str, default='x64', dest='target_architecture', help='Target architecture of the build')
 parser.add_argument('-s', '--stevedore', action='store_true', dest='use_stevedore', help='Use stevedore (used for internal builds)')
 parser.add_argument('-n', '--ninja', action='store_true', dest='use_ninja', help='Generate Ninja build files')
 parser.add_argument('-t', '--build_type', default='Release', dest='build_type', help='Build type to do (Release, Debug, ...)')
@@ -21,6 +20,9 @@ parser.add_argument('-z', '--zap', '-c', '--clean', action='store_true', dest='c
 parser.add_argument('-v', '--verbose', action='store_true', dest='verbose_build', help='Make CMake verbose')
 parser.add_argument('--yamato', action='store_true', dest='yamato_build', help='Used internally for CI')
 args = parser.parse_args()
+
+# To build for arm64, Visual Studio 2022 is needed.
+vs_generator_name = "Visual Studio 16 2019" if args.target_architecture.lower() in ['x64', 'amd64'] else "Visual Studio 17 2022"
 
 curdir = os.path.dirname(os.path.abspath(__file__))
 builddir = os.path.join(curdir, 'build')
@@ -85,7 +87,7 @@ config_args.append('-DYAMATO' + ('=ON' if args.yamato_build else '=OFF'))
 if sys.platform.startswith('darwin'):
     config_args.append(f"-DCMAKE_OSX_DEPLOYMENT_TARGET={osx_deployment_target}")
 elif sys.platform.startswith('win'):
-    arch = 'x64' if platform.machine() in ['x86_64', 'AMD64'] else 'ARM64'
+    arch = 'x64' if args.target_architecture.lower() in ['x64', 'amd64'] else 'ARM64'
     config_args.append('-A ' + arch)
 
 # Generator selection

--- a/build_win.cmd
+++ b/build_win.cmd
@@ -1,5 +1,5 @@
 choco -v -y install 7zip
-py -3 build.py --stevedore --verbose --clean --yamato
+py -3 build.py --stevedore --verbose --clean --yamato --target %PROCESSOR_ARCHITECTURE%
 IF %ERRORLEVEL% NEQ 0 (
     echo Build command failed on Windows with error code: %ERRORLEVEL%
     exit %ERRORLEVEL%


### PR DESCRIPTION
## Purpose of this PR:
Add a build job for ARM64 Windows.
On ARM64 Win bokken VM, it is x64 version Python 3 installed. Because of that, `platform.machine()` returns `AMD64` even it is a `ARM64` machine. This is a similar issue to x64 version CMake on ARM64 Win: CMAKE_SYSTEM_PROCESSOR returns AMD64.

Because of that, I decide to:
- Add a new flag `--target` to build.py script
- In `build.cmd`, pass  `--target %PROCESSOR_ARCHITECTURE%` which is retrieved from the system directly to `build.py`. By doing this, we can work around the issue above. 

***JIRA ticket:*
[FBX-517](https://jira.unity3d.com/browse/FBX-517) Create Yamato job to build library on Win ARM64