### PR TITLE
CI: Remove 2022.2, 2023.1, trunk and add 2022.3 in CI of release 5.0 branch

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -1,9 +1,7 @@
 editors:
   - version: 2020.3
   - version: 2021.3
-  - version: 2022.2
-  - version: 2023.1
-  - version: trunk
+  - version: 2022.3
 
 mac_platform: &mac
   name: mac


### PR DESCRIPTION
## Purpose of this PR:
Remove 2022.2, 2023.1, trunk from CI of release/5.0 branch.
Add 2022.3 to CI of release/5.0 branch.

**JIRA ticket:**
[FBX-494](https://jira.unity3d.com/browse/FBX-494) CI: Editor cleanup in CI of both FBX SDK and FBX Exporter for release/5.0 branch